### PR TITLE
feat: security triage mode and archive recursion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,18 +87,21 @@ jobs:
           go-version: stable
           cache: true
 
+      # Pinned: GoReleaser > v2.15.x turns the `brews` deprecation into a hard
+      # `check` error. Pinned to v2.15.4 (keeps it a warning, still emits the
+      # cross-platform Homebrew formula) until the config migrates off `brews`.
       - name: Check GoReleaser config
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: '~> v2'
+          version: 'v2.15.4'
           args: check
 
       - name: Test GoReleaser build
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: '~> v2'
+          version: 'v2.15.4'
           args: build --snapshot --clean
 
       - name: Upload snapshot artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,14 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Pinned to v2.15.4: newer GoReleaser hard-errors on the deprecated `brews`
+      # config. v2.15.4 still emits the cross-platform Homebrew formula. Revisit
+      # when migrating off `brews` (note: homebrew_casks is macOS-only).
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6.1.0
         with:
           distribution: goreleaser
-          version: '~> v2'
+          version: 'v2.15.4'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,10 @@ txtr/
 ├── internal/
 │   ├── binary/             # ELF/PE/Mach-O parsing
 │   ├── extractor/          # String extraction (ASCII/UTF-8/UTF-16/UTF-32)
-│   ├── printer/            # Output (text/JSON/color)
-│   └── stats/              # Statistics mode
+│   ├── printer/            # Output (text/JSON/color/triage)
+│   ├── stats/              # Statistics mode
+│   ├── triage/             # Entropy + classification + secret detection
+│   └── archive/            # Recursive archive walking (zip/tar/gz/bz2/xz/zst/ar)
 ├── testdata/fuzz/          # Fuzz corpus
 └── .github/workflows/      # CI/CD
 ```
@@ -61,7 +63,11 @@ txtr/
 - `extractor.ExtractStrings()`: Dispatches to encoding-specific extractors
 - `printer.PrintString()`: Formats output with colors/offsets
 - `printer.JSONPrinter`: Collector pattern for structured output
-- `stats.Statistics`: Aggregates metrics for `--stats` mode
+- `printer.TriagePrinter`: Annotated triage output (tags each string by secret/entropy/category)
+- `stats.Statistics`: Aggregates metrics for `--stats` mode (incl. triage rollup)
+- `triage.Classify()`: Pure analysis (entropy + classification + secret rules); no internal deps, so `printer` and `stats` both reuse it without import cycles
+- `archive.Walk()`: Recurses archives/compressed containers, emitting each leaf file as a stream (`!/`-separated virtual paths) with depth + decompressed-size bomb guards; depends only on stdlib + pure-Go xz/zstd
+- `extractFile()` (cmd/txtr): single routing seam used by every mode — recursion > data-only > whole-file — so `--recurse` composes with text/triage/stats/JSON
 
 **Key Patterns:**
 - Dependency injection: printFunc callback for testability
@@ -74,6 +80,8 @@ txtr/
 **UTF-8 modes:** `-U locale/escape/hex/highlight`
 **Filtering:** `-m <pattern>`, `-M <exclude>`, `-i` (case-insensitive)
 **Output:** `-f` (filename), `-t o/d/x` (offset), `--color auto/always/never`, `-j` (JSON), `--stats`
+**Triage:** `--triage` (entropy/classification/secret tags), `--secrets` (secrets+high-entropy only), `--min-entropy <float>` (default 4.5)
+**Recursion:** `-r`/`--recurse` (descend into zip/apk/tar/gz/bz2/xz/zst/deb), `--max-depth` (default 8), `--max-decompressed-size` (default 2 GiB)
 **Parallel:** `-P N` (0=auto CPUs, 1=sequential)
 **Performance:** `--no-mmap`, `--mmap-threshold` (default: 1MB)
 
@@ -83,15 +91,17 @@ txtr/
 **Parallel Processing:** Auto-detects CPUs, maintains output order
 **Pattern Filtering:** Regex match/exclude with ReDoS protection
 **Statistics Mode:** `--stats` for quick triage (encoding dist, length buckets, top-5 longest)
+**Security Triage:** `--triage`/`--secrets` for entropy scoring, content classification, and secret detection (composes with `-j` and `--stats`)
+**Archive Recursion:** `--recurse` descends into zip/apk/tar/gz/bz2/xz/zst/deb containers, scanning each member with `!/` virtual paths and decompression-bomb guards
 **JSON Output:** `--json` for automation (works with jq)
 **Color Output:** Auto TTY detection, respects NO_COLOR env var
-**Fuzzing:** 9 fuzz targets (string extraction, binary parsing, filtering) with CVE coverage
+**Fuzzing:** 11 fuzz targets (string extraction, binary parsing, filtering, triage classification, archive walking) with CVE coverage
 
 ## Testing
 
 **Unit tests:** 18 test files covering all packages
-**Fuzz tests:** 9 targets (3min on PR, 1hr daily, manual dispatch)
-**Benchmarks:** 136 benchmarks across all components (CI tracked, 30-day retention)
+**Fuzz tests:** 11 targets (3min on PR, 1hr daily, manual dispatch)
+**Benchmarks:** 130+ benchmarks across all components, incl. triage entropy/classify/secret-scan and a plain-vs-triage overhead comparison (CI tracked, 30-day retention)
 
 **Coverage:**
 - CVE-2020-14040 (UTF-16 infinite loop)
@@ -105,12 +115,14 @@ txtr/
 - mmap speedup: 2-3x for large files
 - Parallel speedup: ~1.8x (2 cores), ~6-7x (8 cores)
 - Binary format detection: <10µs
+- Triage entropy: ~470 MB/s (256B) to ~2.5 GB/s (4KB); zero-alloc
+- Triage per-string overhead: ~2.4µs/string on a realistic mix (~3.9x plain output); short strings (<12B) skip the secret-rule scan, so the cost concentrates on long/interesting strings
 
 ## Dependencies
 
-**Runtime:** Kong v1.14.0, golang.org/x/exp/mmap, Go 1.26 stdlib
+**Runtime:** Kong v1.14.0, golang.org/x/exp/mmap, ulikunitz/xz + klauspost/compress (pure-Go xz/zstd for `--recurse`), Go 1.26 stdlib
 **Build:** GoReleaser v2.12.7, Ko (containerized), golangci-lint v2.9.0
-**Key:** Zero CGO, fully static binaries (~3.8MB)
+**Key:** Zero CGO, fully static binaries (~7MB; grew from ~3.8MB with the pure-Go zstd/xz decoders added for `--recurse`)
 
 ## Build Configuration
 
@@ -136,6 +148,16 @@ txtr -m '\S+@\S+\.\S+' file.bin
 
 # Quick triage
 txtr --stats malware.exe
+
+# Security triage: secrets, high-entropy blobs, classification
+txtr --triage firmware.bin
+txtr --secrets firmware.bin
+txtr --triage -j firmware.bin | jq '.files[0].strings[] | select((.secrets|length)>0)'
+
+# Archive recursion: descend into containers, then triage every member
+txtr -r --secrets app.apk
+txtr -r --triage pkg.deb          # ar -> data.tar.xz -> ELF binaries
+txtr -r -j firmware.tar.gz | jq '.files[0].strings[] | {file, value}'
 
 # Parallel processing with metadata
 txtr -P 8 -f -t x --color=always *.bin

--- a/README.md
+++ b/README.md
@@ -251,6 +251,78 @@ Statistics for binary.exe:
 - With filters: "How many email addresses are embedded?"
 - Per-file analysis: Compare statistics across multiple files
 
+### Security Triage
+
+The `--triage` flag turns `txtr` into a first-pass security triage tool. Every extracted string is
+scored for Shannon entropy, classified by content (URL, email, IPv4/IPv6, domain, file path, hex,
+base64, UUID), and scanned for likely secrets (AWS keys, PEM private keys, GitHub/Slack/Stripe
+tokens, Google API keys, JWTs, and generic `key=value` assignments). Each string is printed with
+its highest-priority tag:
+
+```bash
+# Annotate every string with its triage tag
+txtr --triage firmware.bin
+
+# Only surface detected secrets and high-entropy blobs
+txtr --secrets firmware.bin
+
+# Tune the high-entropy threshold (bits/byte, default 4.5)
+txtr --triage --min-entropy 5.0 firmware.bin
+
+# Triage as JSON for CI gates (entropy/categories/secrets per string)
+txtr --triage -j firmware.bin | jq '.files[0].strings[] | select((.secrets|length)>0)'
+
+# Triage rollup in statistics mode
+txtr --triage --stats firmware.bin
+```
+
+```
+[SECRET]   0x001a40 AWS Access Key        AKIAIOSFODNN7EXAMPLE
+[SECRET]   0x002f10 PEM Private Key       -----BEGIN RSA PRIVATE KEY-----
+[HIGH-ENT] 0x004012 entropy=7.8           gB7x9K2pQ4rT6yU8wA1zC3vN5mL0jH...
+[URL]      0x005120 https://c2.example.com/beacon
+[IPv4]     0x006004 10.0.0.5
+```
+
+**Use cases:**
+- Firmware/malware triage: surface embedded credentials, C2 URLs, and packed (high-entropy) blobs
+- CI secret scanning: fail builds when `--triage -j` reports findings in shipped binaries
+- Composition overview: `--triage --stats` shows how many URLs, IPs, and secrets a binary contains
+
+### Archive Recursion
+
+The `--recurse` (`-r`) flag descends into archive and compressed-container files and
+extracts strings from every contained file, rather than scanning the raw (often compressed)
+container bytes. Each string is labelled with a virtual path using `!/` to separate nesting
+levels (e.g. `app.apk!/classes.dex`, `pkg.deb!/data.tar!/usr/bin/htop`).
+
+Supported containers: **zip** (and zip-based `.apk`/`.jar`/`.ipa`/`.aar`), **tar**, **gzip**,
+**bzip2**, **xz**, **zstd**, and **ar** (`.deb`). Nested combinations are recursed automatically.
+
+```bash
+# Pull strings out of every file inside an APK (DEX, resources, native libs)
+txtr -r app.apk
+
+# Triage a Debian package: descends ar -> data.tar.xz -> ELF binaries
+txtr -r --triage pkg.deb
+
+# Scan firmware images, keeping virtual paths for locating findings
+txtr -r -f firmware.tar.gz
+
+# Combine with secrets scanning across a whole archive tree
+txtr -r --secrets app.apk
+
+# JSON with per-member virtual paths
+txtr -r -j pkg.deb | jq '.files[0].strings[] | {file, value}'
+```
+
+Why it matters: an APK or `.deb` stores its real content compressed, so a plain scan only
+sees high-entropy blobs. Recursion exposes the URLs, domains, IPs, and secrets hidden inside.
+
+**Safety:** recursion is bounded against decompression bombs and pathological nesting:
+- `--max-depth` (default 8) limits archive nesting; deeper members are scanned as opaque leaves
+- `--max-decompressed-size` (default 2 GiB, `<0` = unlimited) caps total decompressed bytes per input
+
 ### JSON Output Format
 
 The `--json` flag outputs results in structured JSON format, perfect for automation, CI/CD pipelines, and integration with tools like `jq`:
@@ -324,6 +396,18 @@ The `--json` flag outputs results in structured JSON format, perfect for automat
 - `--stats`: Output statistics summary instead of strings (for analysis and triage)
 - `--stats-per-file`: Show per-file statistics instead of aggregated (requires --stats)
 
+### Security Triage Options
+- `--triage`: Tag each string with entropy, content classification, and detected secrets
+- `--secrets`: Only surface detected secrets and high-entropy strings (implies `--triage`)
+- `--min-entropy=<float>`: Entropy threshold (bits/byte) for high-entropy flagging (default: 4.5)
+- Composable with `-j`/`--json` (adds `entropy`/`categories`/`secrets` fields) and `--stats` (adds a triage rollup)
+
+### Archive Recursion Options
+- `-r`, `--recurse`: Recurse into archives/compressed files (zip/apk/jar/tar/gz/bz2/xz/zst/deb), scanning each contained file
+- `--max-depth=<n>`: Maximum archive nesting depth when recursing (default: 8)
+- `--max-decompressed-size=<bytes>`: Max total decompressed bytes per input, a decompression-bomb guard (default: 2 GiB; `<0` = unlimited)
+- Composes with all output modes (`--triage`, `--secrets`, `--stats`, `-j`); each string is labelled with a `!/`-separated virtual path
+
 ### Pattern Filtering Options
 - `-m <pattern>`, `--match=<pattern>`: Only show strings matching regex pattern (can be specified multiple times for OR logic)
 - `-M <pattern>`, `--exclude=<pattern>`: Exclude strings matching regex pattern (can be specified multiple times)
@@ -375,6 +459,8 @@ The `--json` flag outputs results in structured JSON format, perfect for automat
 - **UTF-8 Unicode Support**: Full UTF-8 multibyte character handling with multiple display modes
 - **Regex Pattern Filtering**: Extract specific patterns (URLs, emails, IPs) or exclude unwanted strings (debug symbols, noise)
 - **Statistics Mode**: Aggregated analysis with encoding distribution, length buckets, and longest strings for quick triage
+- **Security Triage**: Entropy scoring, content classification, and secret detection (`--triage`/`--secrets`) for firmware/malware analysis and CI secret scanning
+- **Archive Recursion**: Descend into zip/apk/tar/gz/bz2/xz/zst/deb containers (`--recurse`) with virtual paths and decompression-bomb guards
 - **Colored Output**: Visual distinction with ANSI colors for filenames, offsets, and string types (auto/always/never)
 - **Memory-Mapped I/O**: Automatic 2x performance boost for files ≥1MB via mmap optimization
 - **Configurable Minimum Length**: Set minimum string length threshold

--- a/cmd/txtr/main.go
+++ b/cmd/txtr/main.go
@@ -5,17 +5,41 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"runtime"
 	"sync"
 
 	"github.com/alecthomas/kong"
+	"github.com/richardwooding/txtr/internal/archive"
 	"github.com/richardwooding/txtr/internal/binary"
 	"github.com/richardwooding/txtr/internal/extractor"
 	"github.com/richardwooding/txtr/internal/printer"
 	"github.com/richardwooding/txtr/internal/stats"
 )
+
+// printFunc is the callback every output mode supplies to receive extracted
+// strings: (string bytes, source path, byte offset within the source, config).
+type printFunc = func([]byte, string, int64, extractor.Config)
+
+// extractFile routes a single input file through the correct extraction path
+// based on config precedence: recursion (archive walk) > data-only (binary
+// sections) > whole-file scan. Extracted strings are delivered to fn. Used by
+// every output mode so recursion composes with text/triage/stats/JSON output.
+func extractFile(filename string, config extractor.Config, fn printFunc) error {
+	if config.Recursive {
+		opts := archive.Options{MaxDepth: config.RecurseMaxDepth, MaxBytes: config.RecurseMaxBytes}
+		return archive.Walk(filename, opts, func(vpath string, r io.Reader) error {
+			extractor.ExtractStrings(r, vpath, config, fn)
+			return nil
+		})
+	}
+	if config.ScanDataOnly {
+		return extractFileWithBinaryParsing(filename, config, fn)
+	}
+	return extractor.ExtractStringsFromFile(filename, config, fn)
+}
 
 // Build information (set by goreleaser via ldflags)
 var (
@@ -46,6 +70,12 @@ type CLI struct {
 	IgnoreCase           bool     `short:"i" name:"ignore-case" help:"Case-insensitive pattern matching"`
 	Stats                bool     `name:"stats" help:"Output statistics summary instead of strings"`
 	StatsPerFile         bool     `name:"stats-per-file" help:"Show per-file statistics instead of aggregated (requires --stats)"`
+	Triage               bool     `name:"triage" help:"Security triage: tag strings by entropy, classification, and detected secrets"`
+	Secrets              bool     `name:"secrets" help:"Only surface detected secrets and high-entropy strings (implies --triage)"`
+	MinEntropy           float64  `name:"min-entropy" default:"4.5" help:"Entropy threshold (bits/byte) for high-entropy flagging in triage mode"`
+	Recurse              bool     `short:"r" name:"recurse" help:"Recurse into archives/compressed files (zip/apk/tar/gz/bz2/xz/zst/deb), scanning each member"`
+	MaxDepth             int      `name:"max-depth" default:"8" help:"Maximum archive nesting depth when recursing"`
+	MaxDecompressedSize  int64    `name:"max-decompressed-size" default:"2147483648" help:"Max total decompressed bytes per input when recursing (bomb guard; <0 = unlimited)"`
 	DisableMmap          bool     `name:"no-mmap" help:"Disable memory-mapped I/O optimization"`
 	MmapThreshold        int64    `name:"mmap-threshold" default:"1048576" help:"Minimum file size (bytes) for using mmap (default: 1MB)"`
 	Version              bool     `short:"v" name:"version" help:"Display version information"`
@@ -135,6 +165,21 @@ func main() {
 		os.Exit(1)
 	}
 
+	// --secrets implies triage (it is a secrets-only filter on triage output)
+	if cli.Secrets {
+		cli.Triage = true
+	}
+
+	// Validate --recurse usage
+	if cli.Recurse && len(cli.Files) == 0 {
+		fmt.Fprintf(os.Stderr, "error: -r/--recurse requires file arguments (cannot be used with stdin)\n")
+		os.Exit(1)
+	}
+	if cli.Recurse && cli.ScanDataOnly {
+		fmt.Fprintf(os.Stderr, "error: -r/--recurse and -d/--data cannot be used together\n")
+		os.Exit(1)
+	}
+
 	// Parse color mode
 	var colorMode extractor.ColorMode
 	switch cli.Color {
@@ -184,6 +229,12 @@ func main() {
 		ExcludePatterns:      excludePatterns,
 		DisableMmap:          cli.DisableMmap,
 		MmapThreshold:        cli.MmapThreshold,
+		TriageMode:           cli.Triage,
+		SecretsOnly:          cli.Secrets,
+		MinEntropy:           cli.MinEntropy,
+		Recursive:            cli.Recurse,
+		RecurseMaxDepth:      cli.MaxDepth,
+		RecurseMaxBytes:      cli.MaxDecompressedSize,
 	}
 
 	// Determine number of parallel workers
@@ -199,6 +250,9 @@ func main() {
 	} else if cli.JSON {
 		// JSON output mode
 		processWithJSON(cli.Files, workers, config)
+	} else if cli.Triage {
+		// Security triage output mode
+		processWithTriage(cli.Files, workers, config)
 	} else if len(cli.Files) == 0 {
 		// Read from stdin
 		extractor.ExtractStrings(os.Stdin, "", config, printer.PrintString)
@@ -208,15 +262,9 @@ func main() {
 	} else {
 		// Process each file sequentially (single file or workers=1)
 		for _, filename := range cli.Files {
-			if config.ScanDataOnly {
-				// Parse binary and extract from data sections only
-				processFileWithBinaryParsing(filename, config)
-			} else {
-				// Regular full-file scanning with automatic mmap optimization
-				if err := extractor.ExtractStringsFromFile(filename, config, printer.PrintString); err != nil {
-					fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
-					continue
-				}
+			if err := extractFile(filename, config, printer.PrintString); err != nil {
+				fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
+				continue
 			}
 		}
 	}
@@ -240,7 +288,14 @@ func processWithJSON(files []string, workers int, config extractor.Config) {
 		jsonPrinter = printer.NewJSONPrinter(config, os.Stdout)
 
 		for _, filename := range files {
-			if config.ScanDataOnly {
+			if config.Recursive {
+				jsonPrinter.SetFileInfo(filename, "archive", nil)
+				if err := extractFile(filename, config, jsonPrinter.PrintString); err != nil {
+					fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
+					jsonPrinter.AddFileResult(filename, "archive", nil, nil, err)
+					continue
+				}
+			} else if config.ScanDataOnly {
 				// Parse binary and extract from data sections
 				processFileWithBinaryParsingJSON(filename, config, jsonPrinter)
 			} else {
@@ -345,78 +400,6 @@ func processFileWithBinaryParsingJSON(filename string, config extractor.Config, 
 	}
 }
 
-// processFileWithBinaryParsing handles binary format detection and section extraction
-func processFileWithBinaryParsing(filename string, config extractor.Config) {
-	// Determine format
-	var format binary.Format
-	var err error
-
-	if config.TargetFormat != "" && config.TargetFormat != "binary" {
-		// User specified a format
-		switch config.TargetFormat {
-		case "elf":
-			format = binary.FormatELF
-		case "pe":
-			format = binary.FormatPE
-		case "macho":
-			format = binary.FormatMachO
-		default:
-			format = binary.FormatRaw
-		}
-	} else {
-		// Auto-detect format
-		format, err = binary.DetectFormat(filename)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
-			return
-		}
-	}
-
-	// Parse binary to get sections
-	sections, err := binary.ParseBinary(filename, format)
-	if err != nil {
-		// Fall back to regular scanning if parsing fails
-		fmt.Fprintf(os.Stderr, "strings: %s: warning: cannot parse as %v, falling back to full scan: %v\n",
-			filename, format, err)
-
-		file, err := os.Open(filename)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
-			return
-		}
-		defer func() {
-			if err := file.Close(); err != nil {
-				fmt.Fprintf(os.Stderr, "strings: %s: error closing file: %v\n", filename, err)
-			}
-		}()
-
-		extractor.ExtractStrings(file, filename, config, printer.PrintString)
-		return
-	}
-
-	// If no sections found (raw binary), scan the whole file
-	if len(sections) == 0 {
-		file, err := os.Open(filename)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
-			return
-		}
-		defer func() {
-			if err := file.Close(); err != nil {
-				fmt.Fprintf(os.Stderr, "strings: %s: error closing file: %v\n", filename, err)
-			}
-		}()
-
-		extractor.ExtractStrings(file, filename, config, printer.PrintString)
-		return
-	}
-
-	// Extract strings from each data section
-	for _, section := range sections {
-		extractor.ExtractFromSection(section.Data, section.Name, section.Offset, filename, config, printer.PrintString)
-	}
-}
-
 // processFilesParallel processes multiple files in parallel using a worker pool
 func processFilesParallel(filenames []string, workers int, config extractor.Config) {
 	// Create channels for jobs and results
@@ -432,18 +415,12 @@ func processFilesParallel(filenames []string, workers int, config extractor.Conf
 				var buf bytes.Buffer
 
 				// Create a print function that writes to the buffer
-				printFunc := func(str []byte, filename string, offset int64, cfg extractor.Config) {
+				printToBuf := func(str []byte, filename string, offset int64, cfg extractor.Config) {
 					printer.PrintStringToWriter(&buf, str, filename, offset, cfg)
 				}
 
-				// Process the file
-				var err error
-				if config.ScanDataOnly {
-					err = processFileWithBinaryParsingToWriter(&buf, j.filename, config)
-				} else {
-					// Use ExtractStringsFromFile with automatic mmap optimization
-					err = extractor.ExtractStringsFromFile(j.filename, config, printFunc)
-				}
+				// Process the file (recursion/data-only/whole-file)
+				err := extractFile(j.filename, config, printToBuf)
 
 				// Send result
 				results <- result{index: j.index, output: buf.String(), err: err}
@@ -479,78 +456,6 @@ func processFilesParallel(filenames []string, workers int, config extractor.Conf
 	}
 }
 
-// processFileWithBinaryParsingToWriter handles binary parsing and writes output to a buffer
-func processFileWithBinaryParsingToWriter(buf *bytes.Buffer, filename string, config extractor.Config) error {
-	// Create a print function that writes to the buffer
-	printFunc := func(str []byte, fname string, offset int64, cfg extractor.Config) {
-		printer.PrintStringToWriter(buf, str, fname, offset, cfg)
-	}
-
-	// Determine format
-	var format binary.Format
-	var err error
-
-	if config.TargetFormat != "" && config.TargetFormat != "binary" {
-		// User specified a format
-		switch config.TargetFormat {
-		case "elf":
-			format = binary.FormatELF
-		case "pe":
-			format = binary.FormatPE
-		case "macho":
-			format = binary.FormatMachO
-		default:
-			format = binary.FormatRaw
-		}
-	} else {
-		// Auto-detect format
-		format, err = binary.DetectFormat(filename)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Parse binary to get sections
-	sections, err := binary.ParseBinary(filename, format)
-	if err != nil {
-		// Fall back to regular scanning if parsing fails
-		file, openErr := os.Open(filename)
-		if openErr != nil {
-			return openErr
-		}
-		defer func() {
-			if closeErr := file.Close(); closeErr != nil {
-				fmt.Fprintf(os.Stderr, "strings: %s: error closing file: %v\n", filename, closeErr)
-			}
-		}()
-
-		extractor.ExtractStrings(file, filename, config, printFunc)
-		return nil
-	}
-
-	// If no sections found (raw binary), scan the whole file
-	if len(sections) == 0 {
-		file, openErr := os.Open(filename)
-		if openErr != nil {
-			return openErr
-		}
-		defer func() {
-			if closeErr := file.Close(); closeErr != nil {
-				fmt.Fprintf(os.Stderr, "strings: %s: error closing file: %v\n", filename, closeErr)
-			}
-		}()
-
-		extractor.ExtractStrings(file, filename, config, printFunc)
-		return nil
-	}
-
-	// Extract strings from each data section
-	for _, section := range sections {
-		extractor.ExtractFromSection(section.Data, section.Name, section.Offset, filename, config, printFunc)
-	}
-	return nil
-}
-
 // processFilesParallelJSON processes multiple files in parallel for JSON output
 func processFilesParallelJSON(filenames []string, workers int, config extractor.Config) *printer.JSONPrinter {
 	// Create channels for jobs and results
@@ -571,7 +476,21 @@ func processFilesParallelJSON(filenames []string, workers int, config extractor.
 				var strings []printer.StringResult
 				var err error
 
-				if config.ScanDataOnly {
+				if config.Recursive {
+					tempPrinter.SetFileInfo(j.filename, "archive", nil)
+					err = extractFile(j.filename, config, tempPrinter.PrintString)
+					if err != nil {
+						results <- jsonFileResult{index: j.index, filename: j.filename, err: err}
+						continue
+					}
+					tempPrinter.FinalizeCurrentFile()
+					if len(tempPrinter.FileResults) > 0 {
+						fileRes := tempPrinter.FileResults[0]
+						strings = fileRes.Strings
+						format = fileRes.Format
+						sections = fileRes.Sections
+					}
+				} else if config.ScanDataOnly {
 					// Process with binary parsing
 					format, sections, strings, err = processFileForJSON(j.filename, config)
 				} else {
@@ -774,7 +693,12 @@ func processWithStats(files []string, workers int, config extractor.Config, perF
 			}
 
 			// Process file with binary parsing if needed
-			if config.ScanDataOnly {
+			if config.Recursive {
+				if err := extractFile(filename, config, collectFunc); err != nil {
+					fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
+					continue
+				}
+			} else if config.ScanDataOnly {
 				if err := processFileWithStatsAndBinaryParsing(filename, config, s); err != nil {
 					fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
 					continue
@@ -809,7 +733,12 @@ func processWithStats(files []string, workers int, config extractor.Config, perF
 	// Sequential processing
 	if len(files) == 1 || workers == 1 {
 		for _, filename := range files {
-			if config.ScanDataOnly {
+			if config.Recursive {
+				if err := extractFile(filename, config, collectFunc); err != nil {
+					fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
+					continue
+				}
+			} else if config.ScanDataOnly {
 				if err := processFileWithStatsAndBinaryParsing(filename, config, aggregated); err != nil {
 					fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
 					continue
@@ -840,7 +769,13 @@ func processWithStats(files []string, workers int, config extractor.Config, perF
 						localCollectFunc = makeFilterTrackingFunc(s, config)
 					}
 
-					if config.ScanDataOnly {
+					if config.Recursive {
+						if err := extractFile(j.filename, config, localCollectFunc); err != nil {
+							fmt.Fprintf(os.Stderr, "strings: %s: %v\n", j.filename, err)
+							results <- nil
+							continue
+						}
+					} else if config.ScanDataOnly {
 						if err := processFileWithStatsAndBinaryParsing(j.filename, config, s); err != nil {
 							fmt.Fprintf(os.Stderr, "strings: %s: %v\n", j.filename, err)
 							results <- nil
@@ -882,6 +817,127 @@ func processWithStats(files []string, workers int, config extractor.Config, perF
 
 	// Output aggregated statistics
 	aggregated.Format(os.Stdout, config.ColorMode)
+}
+
+// processWithTriage processes files or stdin with security-triage output.
+func processWithTriage(files []string, workers int, config extractor.Config) {
+	// stdin case
+	if len(files) == 0 {
+		tp := printer.NewTriagePrinter(config, os.Stdout)
+		extractor.ExtractStrings(os.Stdin, "", config, tp.PrintString)
+		return
+	}
+
+	// Parallel processing for multiple files (output buffered per file, in order)
+	if len(files) > 1 && workers > 1 {
+		jobs := make(chan job, len(files))
+		results := make(chan result, len(files))
+
+		var wg sync.WaitGroup
+		for range workers {
+			wg.Go(func() {
+				for j := range jobs {
+					var buf bytes.Buffer
+					tp := printer.NewTriagePrinter(config, &buf)
+					err := extractFile(j.filename, config, tp.PrintString)
+					results <- result{index: j.index, output: buf.String(), err: err}
+				}
+			})
+		}
+
+		for i, filename := range files {
+			jobs <- job{filename: filename, index: i}
+		}
+		close(jobs)
+
+		go func() {
+			wg.Wait()
+			close(results)
+		}()
+
+		outputs := make([]result, len(files))
+		for r := range results {
+			outputs[r.index] = r
+		}
+
+		for _, r := range outputs {
+			if r.err != nil {
+				fmt.Fprintf(os.Stderr, "strings: %s: %v\n", files[r.index], r.err)
+				continue
+			}
+			fmt.Print(r.output)
+		}
+		return
+	}
+
+	// Sequential (single file or workers=1)
+	tp := printer.NewTriagePrinter(config, os.Stdout)
+	for _, filename := range files {
+		if err := extractFile(filename, config, tp.PrintString); err != nil {
+			fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
+			continue
+		}
+	}
+}
+
+// extractFileWithBinaryParsing detects the binary format, extracts strings from
+// its data sections (falling back to a full scan when parsing fails or no
+// sections are found), and routes each string through printFunc.
+func extractFileWithBinaryParsing(filename string, config extractor.Config, printFunc func([]byte, string, int64, extractor.Config)) error {
+	// Determine format
+	var format binary.Format
+	var err error
+
+	if config.TargetFormat != "" && config.TargetFormat != "binary" {
+		switch config.TargetFormat {
+		case "elf":
+			format = binary.FormatELF
+		case "pe":
+			format = binary.FormatPE
+		case "macho":
+			format = binary.FormatMachO
+		default:
+			format = binary.FormatRaw
+		}
+	} else {
+		format, err = binary.DetectFormat(filename)
+		if err != nil {
+			return err
+		}
+	}
+
+	sections, err := binary.ParseBinary(filename, format)
+	if err != nil {
+		// Fall back to regular scanning if parsing fails
+		return scanWholeFile(filename, config, printFunc)
+	}
+
+	// If no sections found (raw binary), scan the whole file
+	if len(sections) == 0 {
+		return scanWholeFile(filename, config, printFunc)
+	}
+
+	// Extract strings from each data section
+	for _, section := range sections {
+		extractor.ExtractFromSection(section.Data, section.Name, section.Offset, filename, config, printFunc)
+	}
+	return nil
+}
+
+// scanWholeFile opens filename and extracts strings from its entire contents.
+func scanWholeFile(filename string, config extractor.Config, printFunc func([]byte, string, int64, extractor.Config)) error {
+	file, openErr := os.Open(filename)
+	if openErr != nil {
+		return openErr
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			fmt.Fprintf(os.Stderr, "strings: %s: error closing file: %v\n", filename, closeErr)
+		}
+	}()
+
+	extractor.ExtractStrings(file, filename, config, printFunc)
+	return nil
 }
 
 // makeFilterTrackingFunc creates a wrapper function that tracks both filtered and unfiltered counts

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,8 @@ go 1.26
 
 require github.com/alecthomas/kong v1.15.0
 
-require golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6
+require (
+	github.com/klauspost/compress v1.18.6
+	github.com/ulikunitz/xz v0.5.15
+	golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6
+)

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,9 @@ github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
+github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
+github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
+github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6 h1:zfMcR1Cs4KNuomFFgGefv5N0czO2XZpUbxGUy8i8ug0=
 golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6/go.mod h1:46edojNIoXTNOhySWIWdix628clX9ODXwPsQuG6hsK0=

--- a/internal/archive/ar.go
+++ b/internal/archive/ar.go
@@ -1,0 +1,70 @@
+package archive
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// arMagic is the global header of a Unix ar archive.
+const arMagic = "!<arch>\n"
+
+// arHeaderSize is the size of each per-member ar header.
+const arHeaderSize = 60
+
+// walkAr parses a Unix ar archive (the container format of Debian .deb files)
+// and recurses into each member. Member layout: a 60-byte header (16-byte name,
+// ..., 10-byte decimal size at offset 48, "`\n" terminator) followed by size
+// bytes of data, padded to an even boundary with a trailing newline.
+//
+// The ar container is uncompressed, so it reads directly from br without
+// budgeting; compressed members (e.g. data.tar.xz) are budgeted downstream.
+func walkAr(name string, br *bufio.Reader, depth int, opts Options, b *budget, fn WalkFunc) error {
+	magic := make([]byte, len(arMagic))
+	if _, err := io.ReadFull(br, magic); err != nil || string(magic) != arMagic {
+		fmt.Fprintf(os.Stderr, "txtr: %s: not a valid ar archive\n", name)
+		return nil
+	}
+
+	hdr := make([]byte, arHeaderSize)
+	for {
+		_, err := io.ReadFull(br, hdr)
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "txtr: %s: ar header read error: %v\n", name, err)
+			return nil
+		}
+
+		member := strings.TrimSuffix(strings.TrimRight(string(hdr[0:16]), " "), "/")
+		size, err := strconv.ParseInt(strings.TrimSpace(string(hdr[48:58])), 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "txtr: %s: invalid ar member size: %v\n", name, err)
+			return nil
+		}
+
+		// Bound the member to its declared size, recurse, then drain whatever
+		// the walker left unread so the next header is correctly aligned.
+		limited := bufio.NewReaderSize(io.LimitReader(br, size), peekSize)
+		child := name + PathSeparator + cleanMemberName(member)
+		walkErr := walkStream(child, limited, depth+1, opts, b, fn)
+		if _, derr := io.Copy(io.Discard, limited); derr != nil && !errors.Is(derr, errBudgetExceeded) {
+			return derr
+		}
+		if walkErr != nil {
+			return walkErr
+		}
+
+		// Skip the 1-byte padding for odd-sized members.
+		if size%2 == 1 {
+			if _, err := io.CopyN(io.Discard, br, 1); err != nil && !errors.Is(err, io.EOF) {
+				return nil
+			}
+		}
+	}
+}

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -1,0 +1,142 @@
+// Package archive provides recursive walking of archive and compressed-container
+// files (zip, tar, gzip, bzip2, xz, zstd, ar/deb), yielding each contained file
+// as a stream so callers can extract strings from inside firmware images,
+// Android APKs, Debian packages, and other nested containers.
+//
+// It depends only on the standard library plus pure-Go xz/zstd decoders, so it
+// preserves txtr's zero-CGO, fully-static build.
+package archive
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// PathSeparator joins an archive path to a member path in virtual paths, e.g.
+// "firmware.tar.gz!/bin/busybox". It mirrors the convention used by jar URLs.
+const PathSeparator = "!/"
+
+// Default limits guarding against decompression bombs and pathological nesting.
+const (
+	DefaultMaxDepth = 8
+	// DefaultMaxBytes caps total decompressed bytes processed per top-level
+	// input (2 GiB), a backstop against decompression bombs.
+	DefaultMaxBytes int64 = 2 << 30
+)
+
+// errBudgetExceeded is returned internally when the decompressed-byte budget is
+// exhausted; Walk treats it as a graceful stop, not a failure.
+var errBudgetExceeded = errors.New("archive: decompressed-size budget exceeded")
+
+// Options configures a Walk.
+type Options struct {
+	// MaxDepth bounds archive nesting; members deeper than this are emitted as
+	// opaque leaves rather than descended into. 0 uses DefaultMaxDepth.
+	MaxDepth int
+	// MaxBytes bounds total decompressed bytes per top-level input. 0 uses
+	// DefaultMaxBytes; negative means unlimited.
+	MaxBytes int64
+}
+
+func (o Options) maxDepth() int {
+	if o.MaxDepth <= 0 {
+		return DefaultMaxDepth
+	}
+	return o.MaxDepth
+}
+
+func (o Options) maxBytes() int64 {
+	if o.MaxBytes == 0 {
+		return DefaultMaxBytes
+	}
+	return o.MaxBytes
+}
+
+// WalkFunc is invoked once per leaf file discovered in the archive tree. path is
+// the virtual path (e.g. "pkg.deb!/data.tar!/usr/bin/htop") and r streams the
+// member's decompressed contents. Returning an error aborts the walk.
+type WalkFunc func(path string, r io.Reader) error
+
+// budget tracks remaining decompressed bytes across a single walk.
+type budget struct {
+	remaining int64
+	unlimited bool
+}
+
+func (b *budget) reader(r io.Reader) io.Reader {
+	if b.unlimited {
+		return r
+	}
+	return &budgetReader{b: b, r: r}
+}
+
+// budgetReader decrements the shared budget as bytes are read and stops the walk
+// once it is exhausted.
+type budgetReader struct {
+	b *budget
+	r io.Reader
+}
+
+func (br *budgetReader) Read(p []byte) (int, error) {
+	if br.b.remaining <= 0 {
+		return 0, errBudgetExceeded
+	}
+	if int64(len(p)) > br.b.remaining {
+		p = p[:br.b.remaining]
+	}
+	n, err := br.r.Read(p)
+	br.b.remaining -= int64(n)
+	return n, err
+}
+
+// Walk opens the file at path, detects its container format, and invokes fn for
+// every leaf file in the (possibly nested) archive tree. A non-archive file is
+// emitted as a single leaf at its own path. Decompression-bomb and depth limits
+// are enforced per Options.
+func Walk(path string, opts Options, fn WalkFunc) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("error opening file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	b := &budget{remaining: opts.maxBytes(), unlimited: opts.maxBytes() < 0}
+	br := bufio.NewReaderSize(f, peekSize)
+
+	// Top-level zip: use random access via the *os.File to avoid buffering the
+	// whole archive (APKs/jars can be hundreds of MB).
+	if detect(br) == FormatZip {
+		err = walkTopLevelZip(path, f, opts, b, fn)
+	} else {
+		err = walkStream(path, br, 0, opts, b, fn)
+	}
+
+	if errors.Is(err, errBudgetExceeded) {
+		fmt.Fprintf(os.Stderr, "txtr: %s: decompression-size limit reached, stopping recursion\n", path)
+		return nil
+	}
+	return err
+}
+
+// IsArchiveName reports whether a filename looks like a supported archive by its
+// extension. Used to decide, before opening, whether recursion is applicable.
+func IsArchiveName(name string) bool {
+	lower := strings.ToLower(name)
+	for _, ext := range archiveExtensions {
+		if strings.HasSuffix(lower, ext) {
+			return true
+		}
+	}
+	return false
+}
+
+var archiveExtensions = []string{
+	".zip", ".jar", ".apk", ".ipa", ".aar", ".war",
+	".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".tar.xz", ".txz",
+	".tar.zst", ".gz", ".bz2", ".xz", ".zst", ".zstd",
+	".deb", ".a", ".ar",
+}

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -1,0 +1,232 @@
+package archive
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// collect walks path and returns a map of virtual-path -> contents for every
+// leaf the walker emits.
+func collect(t *testing.T, path string, opts Options) map[string]string {
+	t.Helper()
+	got := map[string]string{}
+	err := Walk(path, opts, func(p string, r io.Reader) error {
+		data, err := io.ReadAll(r)
+		if err != nil {
+			return err
+		}
+		got[p] = string(data)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Walk(%s) error: %v", path, err)
+	}
+	return got
+}
+
+func writeTemp(t testing.TB, name string, data []byte) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, data, 0o600); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+	return p
+}
+
+func makeZip(t testing.TB, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	// deterministic order
+	names := make([]string, 0, len(files))
+	for n := range files {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		w, err := zw.Create(n)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(files[n])); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func makeTar(t testing.TB, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	names := make([]string, 0, len(files))
+	for n := range files {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		body := files[n]
+		if err := tw.WriteHeader(&tar.Header{Name: n, Mode: 0o600, Size: int64(len(body)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func gz(t testing.TB, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	if _, err := gw.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestWalkZip(t *testing.T) {
+	z := makeZip(t, map[string]string{"a.txt": "alpha", "dir/b.txt": "bravo"})
+	path := writeTemp(t, "test.zip", z)
+	got := collect(t, path, Options{})
+
+	if got[path+"!/a.txt"] != "alpha" {
+		t.Errorf("a.txt = %q, want alpha", got[path+"!/a.txt"])
+	}
+	if got[path+"!/dir/b.txt"] != "bravo" {
+		t.Errorf("dir/b.txt = %q, want bravo", got[path+"!/dir/b.txt"])
+	}
+}
+
+func TestWalkTarGz(t *testing.T) {
+	tarball := makeTar(t, map[string]string{"./etc/passwd": "root:x:0:0", "bin/sh": "ELFsh"})
+	path := writeTemp(t, "test.tar.gz", gz(t, tarball))
+	got := collect(t, path, Options{})
+
+	// The .gz layer is stripped, so members hang off the decompressed .tar name.
+	base := strings.TrimSuffix(path, ".gz")
+	if got[base+"!/etc/passwd"] != "root:x:0:0" {
+		t.Errorf("etc/passwd = %q (keys: %v)", got[base+"!/etc/passwd"], keys(got))
+	}
+	if got[base+"!/bin/sh"] != "ELFsh" {
+		t.Errorf("bin/sh = %q", got[base+"!/bin/sh"])
+	}
+}
+
+func TestWalkNestedZipInTar(t *testing.T) {
+	inner := makeZip(t, map[string]string{"secret.txt": "deep"})
+	tarball := makeTar(t, map[string]string{"payload.zip": string(inner)})
+	path := writeTemp(t, "outer.tar", tarball)
+	got := collect(t, path, Options{})
+
+	want := path + "!/payload.zip!/secret.txt"
+	if got[want] != "deep" {
+		t.Errorf("nested member %q = %q, want deep (got keys: %v)", want, got[want], keys(got))
+	}
+}
+
+func TestWalkPlainFile(t *testing.T) {
+	// A non-archive file is emitted as a single leaf at its own path.
+	path := writeTemp(t, "plain.bin", []byte("just some bytes"))
+	got := collect(t, path, Options{})
+	if len(got) != 1 || got[path] != "just some bytes" {
+		t.Errorf("plain file walk = %v, want single leaf with raw bytes", got)
+	}
+}
+
+func TestMaxDepthStopsDescending(t *testing.T) {
+	// zip inside tar; with MaxDepth=1 the inner zip is emitted as an opaque leaf
+	// rather than descended into.
+	inner := makeZip(t, map[string]string{"secret.txt": "deep"})
+	tarball := makeTar(t, map[string]string{"payload.zip": string(inner)})
+	path := writeTemp(t, "outer.tar", tarball)
+
+	got := collect(t, path, Options{MaxDepth: 1})
+	for k := range got {
+		if strings.Contains(k, "secret.txt") {
+			t.Errorf("MaxDepth=1 should not have descended into inner zip; got %q", k)
+		}
+	}
+	// The inner zip itself should appear as a leaf.
+	if _, ok := got[path+"!/payload.zip"]; !ok {
+		t.Errorf("expected inner zip as leaf; got keys %v", keys(got))
+	}
+}
+
+func TestMaxBytesBudget(t *testing.T) {
+	// A gzip member that decompresses to more than the budget is truncated
+	// gracefully (no error, partial data).
+	big := bytes.Repeat([]byte("A"), 1<<20) // 1 MiB
+	path := writeTemp(t, "big.gz", gz(t, big))
+
+	var total int
+	err := Walk(path, Options{MaxBytes: 4096}, func(_ string, r io.Reader) error {
+		n, _ := io.Copy(io.Discard, r)
+		total += int(n)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Walk error: %v", err)
+	}
+	if total > 4096 {
+		t.Errorf("read %d bytes, want <= budget 4096", total)
+	}
+}
+
+func TestIsArchiveName(t *testing.T) {
+	yes := []string{"a.zip", "b.APK", "c.tar.gz", "d.tgz", "e.deb", "f.tar.xz", "g.zst"}
+	no := []string{"a.txt", "b.elf", "c.so", "d"}
+	for _, n := range yes {
+		if !IsArchiveName(n) {
+			t.Errorf("IsArchiveName(%q) = false, want true", n)
+		}
+	}
+	for _, n := range no {
+		if IsArchiveName(n) {
+			t.Errorf("IsArchiveName(%q) = true, want false", n)
+		}
+	}
+}
+
+func keys(m map[string]string) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	return ks
+}
+
+func FuzzWalkStream(f *testing.F) {
+	f.Add(makeZip(f, map[string]string{"x": "y"}))
+	f.Add(gz(f, []byte("hello")))
+	f.Add([]byte("not an archive"))
+	f.Add([]byte("!<arch>\n"))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		path := writeTemp(t, "fuzz.bin", data)
+		// Must never panic; errors are acceptable. Bound the budget so fuzzed
+		// bombs cannot run away.
+		_ = Walk(path, Options{MaxBytes: 1 << 20, MaxDepth: 4}, func(_ string, r io.Reader) error {
+			_, _ = io.Copy(io.Discard, r)
+			return nil
+		})
+	})
+}

--- a/internal/archive/detect.go
+++ b/internal/archive/detect.go
@@ -1,0 +1,65 @@
+package archive
+
+import (
+	"bufio"
+	"bytes"
+)
+
+// Format identifies a container/compression format.
+type Format int
+
+// Supported formats.
+const (
+	FormatNone  Format = iota // not a recognized archive (leaf file)
+	FormatZip                 // zip and zip-based (apk/jar/ipa/...)
+	FormatTar                 // uncompressed tar
+	FormatGzip                // gzip stream
+	FormatBzip2               // bzip2 stream
+	FormatXz                  // xz stream
+	FormatZstd                // zstandard stream
+	FormatAr                  // Unix ar archive (Debian .deb)
+)
+
+// peekSize is the number of leading bytes inspected for magic detection. Tar's
+// "ustar" magic lives at offset 257, so we need at least 263 bytes.
+const peekSize = 512
+
+// detect inspects the leading bytes of br (without consuming them) and returns
+// the container format, or FormatNone for a leaf file.
+func detect(br *bufio.Reader) Format {
+	hdr, _ := br.Peek(peekSize)
+
+	switch {
+	case hasPrefix(hdr, []byte{0x50, 0x4b, 0x03, 0x04}),
+		hasPrefix(hdr, []byte{0x50, 0x4b, 0x05, 0x06}),
+		hasPrefix(hdr, []byte{0x50, 0x4b, 0x07, 0x08}):
+		return FormatZip
+	case hasPrefix(hdr, []byte{0x1f, 0x8b}):
+		return FormatGzip
+	case hasPrefix(hdr, []byte{0x42, 0x5a, 0x68}): // "BZh"
+		return FormatBzip2
+	case hasPrefix(hdr, []byte{0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00}): // xz
+		return FormatXz
+	case hasPrefix(hdr, []byte{0x28, 0xb5, 0x2f, 0xfd}): // zstd
+		return FormatZstd
+	case hasPrefix(hdr, []byte("!<arch>\n")): // ar / .deb
+		return FormatAr
+	case isTar(hdr):
+		return FormatTar
+	default:
+		return FormatNone
+	}
+}
+
+func hasPrefix(b, prefix []byte) bool {
+	return len(b) >= len(prefix) && bytes.Equal(b[:len(prefix)], prefix)
+}
+
+// isTar checks for the POSIX "ustar" magic at offset 257.
+func isTar(hdr []byte) bool {
+	if len(hdr) < 263 {
+		return false
+	}
+	magic := hdr[257:262]
+	return bytes.Equal(magic, []byte("ustar"))
+}

--- a/internal/archive/walk.go
+++ b/internal/archive/walk.go
@@ -1,0 +1,174 @@
+package archive
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bufio"
+	"bytes"
+	"compress/bzip2"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/ulikunitz/xz"
+)
+
+// zipMemoryCap bounds how many bytes a *nested* zip stream is buffered into
+// memory (zip needs random access). Larger nested zips are processed partially.
+const zipMemoryCap = 512 << 20
+
+// walkStream detects the format of the stream named name and either descends
+// into it (archives/compressors) or emits it as a leaf via fn.
+//
+// Budget accounting is applied only at decompression-expansion points (the
+// outputs of compressors and zip members); traversal of uncompressed containers
+// (tar/ar) is bounded by the on-disk file size and needs no budgeting.
+func walkStream(name string, br *bufio.Reader, depth int, opts Options, b *budget, fn WalkFunc) error {
+	// At the depth limit, stop descending and treat the stream as a leaf so its
+	// raw bytes are still scanned. depth counts containers already opened to
+	// reach this stream, so MaxDepth=1 opens only the top-level container.
+	if depth >= opts.maxDepth() {
+		return fn(name, br)
+	}
+
+	switch detect(br) {
+	case FormatZip:
+		return walkZipStream(name, br, depth, opts, b, fn)
+	case FormatTar:
+		return walkTar(name, br, depth, opts, b, fn)
+	case FormatAr:
+		return walkAr(name, br, depth, opts, b, fn)
+	case FormatGzip:
+		return walkCompressed(name, ".gz", br, depth, opts, b, fn, func(r io.Reader) (io.Reader, error) {
+			return gzip.NewReader(r)
+		})
+	case FormatBzip2:
+		return walkCompressed(name, ".bz2", br, depth, opts, b, fn, func(r io.Reader) (io.Reader, error) {
+			return bzip2.NewReader(r), nil
+		})
+	case FormatXz:
+		return walkCompressed(name, ".xz", br, depth, opts, b, fn, func(r io.Reader) (io.Reader, error) {
+			return xz.NewReader(r)
+		})
+	case FormatZstd:
+		return walkCompressed(name, ".zst", br, depth, opts, b, fn, func(r io.Reader) (io.Reader, error) {
+			zr, err := zstd.NewReader(r)
+			if err != nil {
+				return nil, err
+			}
+			return zr.IOReadCloser(), nil
+		})
+	default:
+		return fn(name, br) // leaf
+	}
+}
+
+// walkCompressed decompresses a single-stream compressor and recurses on the
+// decompressed content (which may itself be a tar or another archive). trimExt
+// is stripped to derive the inner name (e.g. "data.tar.xz" -> "data.tar").
+func walkCompressed(name, trimExt string, br *bufio.Reader, depth int, opts Options, b *budget, fn WalkFunc, open func(io.Reader) (io.Reader, error)) error {
+	dr, err := open(br)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "txtr: %s: cannot decompress (%v), scanning raw\n", name, err)
+		return fn(name, br)
+	}
+	inner := strings.TrimSuffix(name, trimExt)
+	if inner == name {
+		inner = name + ".out"
+	}
+	// Budget the decompressed output: this is where bomb expansion occurs.
+	return walkStream(inner, bufio.NewReaderSize(b.reader(dr), peekSize), depth+1, opts, b, fn)
+}
+
+func walkTar(name string, br *bufio.Reader, depth int, opts Options, b *budget, fn WalkFunc) error {
+	tr := tar.NewReader(br)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			if errors.Is(err, errBudgetExceeded) {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "txtr: %s: tar read error: %v\n", name, err)
+			return nil
+		}
+		// Process regular files only. 0 is the legacy regular-file flag used by
+		// old tar writers (modern equivalent of the deprecated TypeRegA).
+		if hdr.Typeflag != tar.TypeReg && hdr.Typeflag != 0 {
+			continue
+		}
+		child := name + PathSeparator + cleanMemberName(hdr.Name)
+		if err := walkStream(child, bufio.NewReaderSize(tr, peekSize), depth+1, opts, b, fn); err != nil {
+			return err
+		}
+	}
+}
+
+// walkTopLevelZip handles a zip file on disk using random access via the
+// *os.File, avoiding buffering the whole archive into memory.
+func walkTopLevelZip(name string, f *os.File, opts Options, b *budget, fn WalkFunc) error {
+	fi, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	zr, err := zip.NewReader(f, fi.Size())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "txtr: %s: cannot open zip: %v\n", name, err)
+		return nil
+	}
+	return walkZipReader(name, zr, 0, opts, b, fn)
+}
+
+// walkZipStream handles a zip arriving as a stream (nested inside another
+// archive). zip requires random access, so the stream is buffered (capped).
+func walkZipStream(name string, br *bufio.Reader, depth int, opts Options, b *budget, fn WalkFunc) error {
+	data, err := io.ReadAll(io.LimitReader(br, zipMemoryCap))
+	if err != nil {
+		if errors.Is(err, errBudgetExceeded) {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "txtr: %s: zip read error: %v\n", name, err)
+		return nil
+	}
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "txtr: %s: cannot open zip: %v\n", name, err)
+		return nil
+	}
+	return walkZipReader(name, zr, depth, opts, b, fn)
+}
+
+// walkZipReader iterates zip members, budgeting each member's decompressed
+// stream.
+func walkZipReader(name string, zr *zip.Reader, depth int, opts Options, b *budget, fn WalkFunc) error {
+	for _, zf := range zr.File {
+		if zf.FileInfo().IsDir() {
+			continue
+		}
+		rc, err := zf.Open()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "txtr: %s: cannot open zip member %q: %v\n", name, zf.Name, err)
+			continue
+		}
+		child := name + PathSeparator + cleanMemberName(zf.Name)
+		err = walkStream(child, bufio.NewReaderSize(b.reader(rc), peekSize), depth+1, opts, b, fn)
+		_ = rc.Close()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// cleanMemberName trims a leading "./" and any leading slash so virtual paths
+// read cleanly.
+func cleanMemberName(name string) string {
+	name = strings.TrimPrefix(name, "./")
+	return strings.TrimPrefix(name, "/")
+}

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -43,6 +43,12 @@ type Config struct {
 	ExcludePatterns      []*regexp.Regexp // Patterns to exclude (blacklist filter)
 	DisableMmap          bool             // Disable memory-mapped I/O optimization
 	MmapThreshold        int64            // Minimum file size (bytes) for using mmap
+	TriageMode           bool             // Enable security triage (entropy/classification/secrets)
+	SecretsOnly          bool             // In triage mode, only surface secrets/high-entropy strings
+	MinEntropy           float64          // Entropy threshold (bits/byte) for high-entropy flagging
+	Recursive            bool             // Recurse into archives/compressed containers
+	RecurseMaxDepth      int              // Max archive nesting depth (0 = default)
+	RecurseMaxBytes      int64            // Max total decompressed bytes (0 = default, <0 = unlimited)
 }
 
 // ExtractStrings reads from reader and extracts printable strings

--- a/internal/printer/benchmark_test.go
+++ b/internal/printer/benchmark_test.go
@@ -367,6 +367,51 @@ func BenchmarkPrintString_ConfigComparison(b *testing.B) {
 	}
 }
 
+// Benchmark: Triage output overhead vs plain text output
+//
+// Quantifies the per-string cost of triage classification (entropy +
+// categorization + secret scan) relative to plain string printing, on a
+// representative mix of plain text, classified content, and secrets.
+func BenchmarkComparison_PlainVsTriage(b *testing.B) {
+	// Representative of a real binary: short strings dominate, with a few
+	// classified/secret strings sprinkled in.
+	mix := [][]byte{
+		[]byte("init"), []byte(".text"), []byte("errno"), []byte("%s: %d\n"),
+		[]byte("GLIBC_2.2.5"), []byte("malloc"), []byte("free"), []byte("__stack_chk"),
+		[]byte("the quick brown fox jumps over the lazy dog"),
+		[]byte("https://www.example.com/path/to/resource"),
+		[]byte("192.168.1.1"),
+		[]byte("AKIAIOSFODNN7EXAMPLE"),
+		[]byte("gB7x9K2pQ4rT6yU8wA1zC3vN5mL0jH4dF6sX8wQ"),
+	}
+
+	plainConfig := extractor.Config{MinLength: 4}
+	triageConfig := extractor.Config{MinLength: 4, TriageMode: true, MinEntropy: 4.5, ColorMode: extractor.ColorNever}
+
+	b.Run("PlainText", func(b *testing.B) {
+		var buf bytes.Buffer
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			for j, str := range mix {
+				PrintStringToWriter(&buf, str, "test.bin", int64(j*64), plainConfig)
+			}
+		}
+	})
+
+	b.Run("Triage", func(b *testing.B) {
+		var buf bytes.Buffer
+		tp := NewTriagePrinter(triageConfig, &buf)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			for j, str := range mix {
+				tp.PrintString(str, "test.bin", int64(j*64), triageConfig)
+			}
+		}
+	})
+}
+
 // Helper function to format length
 func formatLength(length int) string {
 	switch {

--- a/internal/printer/color.go
+++ b/internal/printer/color.go
@@ -13,6 +13,8 @@ const (
 	AnsiReset = "\x1b[0m"
 	// AnsiCyan sets text color to cyan.
 	AnsiCyan = "\x1b[36m"
+	// AnsiRed sets text color to red.
+	AnsiRed = "\x1b[31m"
 	// AnsiYellow sets text color to yellow.
 	AnsiYellow = "\x1b[33m"
 	// AnsiGreen sets text color to green.

--- a/internal/printer/json.go
+++ b/internal/printer/json.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/richardwooding/txtr/internal/extractor"
+	"github.com/richardwooding/txtr/internal/triage"
 )
 
 // StringResult represents a single extracted string in JSON format
@@ -20,6 +21,11 @@ type StringResult struct {
 	Length    int    `json:"length"`
 	Encoding  string `json:"encoding"`
 	Section   string `json:"section,omitempty"`
+	// Triage fields (populated only in --triage mode)
+	Entropy     float64                `json:"entropy,omitempty"`
+	Categories  []string               `json:"categories,omitempty"`
+	Secrets     []triage.SecretFinding `json:"secrets,omitempty"`
+	HighEntropy bool                   `json:"high_entropy,omitempty"`
 }
 
 // JSONOutput represents the complete JSON output structure
@@ -95,9 +101,24 @@ func (jp *JSONPrinter) PrintString(str []byte, filename string, offset int64, co
 		Encoding:  getEncodingName(config.Encoding),
 	}
 
-	// Only include filename if PrintFileName is enabled or it's different from stdin
-	if config.PrintFileName && filename != "" {
+	// Include filename when requested, or always when recursing so each archive
+	// member is identified by its virtual path.
+	if (config.PrintFileName || config.Recursive) && filename != "" {
 		result.File = filename
+	}
+
+	// Enrich with triage analysis when enabled.
+	if config.TriageMode {
+		res := triage.Classify(str, config.MinEntropy)
+		if config.SecretsOnly && !res.Interesting() {
+			return
+		}
+		result.Entropy = res.Entropy
+		result.HighEntropy = res.HighEntropy
+		result.Secrets = res.Secrets
+		for _, c := range res.Categories {
+			result.Categories = append(result.Categories, string(c))
+		}
 	}
 
 	jp.currentStrings = append(jp.currentStrings, result)

--- a/internal/printer/triage.go
+++ b/internal/printer/triage.go
@@ -1,0 +1,144 @@
+package printer
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/richardwooding/txtr/internal/extractor"
+	"github.com/richardwooding/txtr/internal/triage"
+)
+
+// triagePreviewLimit caps how many bytes of a string are shown in the preview
+// column of triage output.
+const triagePreviewLimit = 80
+
+// TriagePrinter formats extracted strings as annotated security-triage lines,
+// tagging each with its highest-priority signal (secret, high-entropy,
+// content category, or plain text). Its PrintString method matches the
+// extractor printFunc signature so it plugs into the standard pipeline.
+type TriagePrinter struct {
+	config   extractor.Config
+	writer   io.Writer
+	useColor bool
+}
+
+// NewTriagePrinter creates a triage printer writing to w (defaulting to stdout).
+func NewTriagePrinter(config extractor.Config, w io.Writer) *TriagePrinter {
+	if w == nil {
+		w = os.Stdout
+	}
+	return &TriagePrinter{
+		config:   config,
+		writer:   w,
+		useColor: ShouldUseColor(config.ColorMode),
+	}
+}
+
+// PrintString classifies a string and emits one annotated line per secret
+// finding, or a single line tagged by entropy/category/text. In SecretsOnly
+// mode, uninteresting strings are suppressed.
+func (tp *TriagePrinter) PrintString(str []byte, filename string, offset int64, config extractor.Config) {
+	res := triage.Classify(str, config.MinEntropy)
+
+	if config.SecretsOnly && !res.Interesting() {
+		return
+	}
+
+	offsetStr := tp.formatOffset(offset)
+	prefix := tp.formatFilename(filename)
+	preview := previewString(str)
+
+	if len(res.Secrets) > 0 {
+		for _, s := range res.Secrets {
+			tag := tp.colorTag("SECRET", severityColor(s.Severity))
+			tp.writeLine(prefix, tag, offsetStr, s.Rule, preview)
+		}
+		return
+	}
+
+	switch {
+	case res.HighEntropy:
+		tag := tp.colorTag("HIGH-ENT", AnsiMagenta)
+		tp.writeLine(prefix, tag, offsetStr, fmt.Sprintf("entropy=%.1f", res.Entropy), preview)
+	case len(res.Categories) > 0:
+		cat := string(res.Categories[0])
+		tag := tp.colorTag(cat, AnsiCyan)
+		tp.writeLine(prefix, tag, offsetStr, "", preview)
+	default:
+		tag := tp.colorTag("TEXT", AnsiDim)
+		tp.writeLine(prefix, tag, offsetStr, "", preview)
+	}
+}
+
+// writeLine emits a single formatted triage line. The detail column is padded
+// to a fixed width but always followed by a separating gap, so an over-long
+// detail label can never run into the preview.
+func (tp *TriagePrinter) writeLine(filenamePrefix, tag, offset, detail, preview string) {
+	line := fmt.Sprintf("%-10s %s", tag, offset)
+	if detail != "" {
+		line += fmt.Sprintf("  %-20s", detail)
+	}
+	line += "  " + preview
+	if _, err := fmt.Fprintf(tp.writer, "%s%s\n", filenamePrefix, line); err != nil {
+		return
+	}
+}
+
+// formatOffset renders the byte offset, honoring an explicit radix and
+// defaulting to hex (offsets are central to triage's locate-it workflow).
+func (tp *TriagePrinter) formatOffset(offset int64) string {
+	var s string
+	switch tp.config.Radix {
+	case "o":
+		s = fmt.Sprintf("%8o", offset)
+	case "d":
+		s = fmt.Sprintf("%8d", offset)
+	default: // "x" or unset
+		s = fmt.Sprintf("0x%06x", offset)
+	}
+	if tp.useColor {
+		s = ColorString(s, AnsiYellow, true)
+	}
+	return s
+}
+
+// formatFilename renders the optional filename prefix.
+func (tp *TriagePrinter) formatFilename(filename string) string {
+	if !tp.config.PrintFileName || filename == "" {
+		return ""
+	}
+	if tp.useColor {
+		return ColorString(filename, AnsiBold+AnsiCyan, true) + ": "
+	}
+	return filename + ": "
+}
+
+// colorTag wraps a bracketed tag in the given color when colors are enabled.
+func (tp *TriagePrinter) colorTag(label, color string) string {
+	tag := "[" + label + "]"
+	if tp.useColor {
+		return ColorString(tag, color, true)
+	}
+	return tag
+}
+
+// severityColor maps a secret severity to an ANSI color.
+func severityColor(sev triage.Severity) string {
+	switch sev {
+	case triage.SeverityHigh:
+		return AnsiBold + AnsiRed
+	case triage.SeverityMedium:
+		return AnsiYellow
+	default:
+		return AnsiCyan
+	}
+}
+
+// previewString returns a single-line, length-capped preview of a string.
+func previewString(str []byte) string {
+	if len(str) <= triagePreviewLimit {
+		return string(str)
+	}
+	return string(str[:triagePreviewLimit]) + "..."
+}

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/richardwooding/txtr/internal/extractor"
 	"github.com/richardwooding/txtr/internal/printer"
+	"github.com/richardwooding/txtr/internal/triage"
 )
 
 // Statistics holds aggregated statistics about extracted strings
@@ -32,6 +33,11 @@ type Statistics struct {
 	EncodingCounts map[string]int
 	LengthBuckets  map[string]int
 
+	// Triage distributions (populated only in --triage mode)
+	CategoryCounts   map[string]int
+	SecretCounts     map[string]int
+	HighEntropyCount int
+
 	// Longest strings
 	LongestStrings []LongestString
 }
@@ -49,6 +55,8 @@ func New(minLength int) *Statistics {
 		MinLength:      minLength,
 		EncodingCounts: make(map[string]int),
 		LengthBuckets:  make(map[string]int),
+		CategoryCounts: make(map[string]int),
+		SecretCounts:   make(map[string]int),
 		LongestStrings: make([]LongestString, 0, 5),
 	}
 }
@@ -88,6 +96,20 @@ func (s *Statistics) Add(str []byte, _ string, offset int64, config extractor.Co
 	// Update length bucket
 	bucket := s.getBucket(length)
 	s.LengthBuckets[bucket]++
+
+	// Triage classification (only when enabled)
+	if config.TriageMode {
+		res := triage.Classify(str, config.MinEntropy)
+		for _, c := range res.Categories {
+			s.CategoryCounts[string(c)]++
+		}
+		for _, sec := range res.Secrets {
+			s.SecretCounts[sec.Rule]++
+		}
+		if res.HighEntropy {
+			s.HighEntropyCount++
+		}
+	}
 }
 
 // detectEncoding classifies the encoding type of a string
@@ -268,6 +290,45 @@ func (s *Statistics) Format(w io.Writer, colorMode extractor.ColorMode) {
 		fmt.Fprintln(w)
 	}
 
+	// Triage summary (categories, secrets, high-entropy)
+	if len(s.CategoryCounts) > 0 || len(s.SecretCounts) > 0 || s.HighEntropyCount > 0 {
+		header := printer.ColorString("Triage summary:", printer.AnsiBold+printer.AnsiCyan, useColor)
+		fmt.Fprintf(w, "  %s\n", header)
+
+		if len(s.SecretCounts) > 0 {
+			rules := make([]string, 0, len(s.SecretCounts))
+			for r := range s.SecretCounts {
+				rules = append(rules, r)
+			}
+			sort.Strings(rules)
+			for _, r := range rules {
+				name := printer.ColorString(r+":", printer.AnsiRed, useColor)
+				count := printer.ColorString(formatNumber(s.SecretCounts[r]), printer.AnsiYellow, useColor)
+				fmt.Fprintf(w, "    %-26s %6s\n", name, count)
+			}
+		}
+
+		if s.HighEntropyCount > 0 {
+			name := printer.ColorString("High-entropy blobs:", printer.AnsiMagenta, useColor)
+			count := printer.ColorString(formatNumber(s.HighEntropyCount), printer.AnsiYellow, useColor)
+			fmt.Fprintf(w, "    %-26s %6s\n", name, count)
+		}
+
+		if len(s.CategoryCounts) > 0 {
+			cats := make([]string, 0, len(s.CategoryCounts))
+			for c := range s.CategoryCounts {
+				cats = append(cats, c)
+			}
+			sort.Strings(cats)
+			for _, c := range cats {
+				name := printer.ColorString(c+":", printer.AnsiCyan, useColor)
+				count := printer.ColorString(formatNumber(s.CategoryCounts[c]), printer.AnsiYellow, useColor)
+				fmt.Fprintf(w, "    %-26s %6s\n", name, count)
+			}
+		}
+		fmt.Fprintln(w)
+	}
+
 	// Longest strings
 	if len(s.LongestStrings) > 0 {
 		header := printer.ColorString("Longest strings:", printer.AnsiBold+printer.AnsiCyan, useColor)
@@ -366,6 +427,17 @@ func (s *Statistics) ToJSON() ([]byte, error) {
 		output["length_distribution"] = s.LengthBuckets
 	}
 
+	// Add triage distributions
+	if len(s.CategoryCounts) > 0 {
+		output["category_distribution"] = s.CategoryCounts
+	}
+	if len(s.SecretCounts) > 0 {
+		output["secret_distribution"] = s.SecretCounts
+	}
+	if s.HighEntropyCount > 0 {
+		output["high_entropy_count"] = s.HighEntropyCount
+	}
+
 	// Add longest strings
 	if len(s.LongestStrings) > 0 {
 		longest := make([]map[string]any, len(s.LongestStrings))
@@ -408,6 +480,15 @@ func (s *Statistics) Merge(other *Statistics) {
 	for bucket, count := range other.LengthBuckets {
 		s.LengthBuckets[bucket] += count
 	}
+
+	// Merge triage distributions
+	for cat, count := range other.CategoryCounts {
+		s.CategoryCounts[cat] += count
+	}
+	for rule, count := range other.SecretCounts {
+		s.SecretCounts[rule] += count
+	}
+	s.HighEntropyCount += other.HighEntropyCount
 
 	// Merge longest strings
 	s.LongestStrings = append(s.LongestStrings, other.LongestStrings...)

--- a/internal/triage/benchmark_test.go
+++ b/internal/triage/benchmark_test.go
@@ -1,0 +1,77 @@
+package triage
+
+import "testing"
+
+// benchmarkInputs covers the distinct code paths through Classify: plain text
+// (no match), a content category, and a detected secret.
+var benchmarkInputs = []struct {
+	name string
+	data []byte
+}{
+	{"PlainText", []byte("the quick brown fox jumps over the lazy dog")},
+	{"URL", []byte("https://www.example.com/path/to/resource?q=1&r=2")},
+	{"IPv4", []byte("192.168.100.200")},
+	{"Base64", []byte("TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcw==")},
+	{"SecretAWS", []byte("AKIAIOSFODNN7EXAMPLE")},
+	{"SecretPEM", []byte("-----BEGIN RSA PRIVATE KEY-----")},
+	{"HighEntropy", []byte("gB7x9K2pQ4rT6yU8wA1zC3vN5mL0jH4dF6sX8wQ")},
+}
+
+// BenchmarkEntropy measures Shannon-entropy throughput across input sizes.
+func BenchmarkEntropy(b *testing.B) {
+	sizes := []int{16, 256, 4096}
+	for _, size := range sizes {
+		data := make([]byte, size)
+		for i := range data {
+			data[i] = byte(i * 7) // deterministic spread across the byte space
+		}
+		b.Run(formatSize(size), func(b *testing.B) {
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = Entropy(data)
+			}
+		})
+	}
+}
+
+// BenchmarkClassify measures full per-string triage cost (entropy +
+// classification + all secret rules) for each input type.
+func BenchmarkClassify(b *testing.B) {
+	for _, tc := range benchmarkInputs {
+		b.Run(tc.name, func(b *testing.B) {
+			b.SetBytes(int64(len(tc.data)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = Classify(tc.data, 4.5)
+			}
+		})
+	}
+}
+
+// BenchmarkDetectSecrets isolates the secret-rule scan (all rules applied).
+func BenchmarkDetectSecrets(b *testing.B) {
+	for _, tc := range benchmarkInputs {
+		b.Run(tc.name, func(b *testing.B) {
+			b.SetBytes(int64(len(tc.data)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = detectSecrets(tc.data)
+			}
+		})
+	}
+}
+
+func formatSize(size int) string {
+	switch size {
+	case 16:
+		return "16B"
+	case 256:
+		return "256B"
+	case 4096:
+		return "4KB"
+	default:
+		return "custom"
+	}
+}

--- a/internal/triage/classify.go
+++ b/internal/triage/classify.go
@@ -1,0 +1,171 @@
+package triage
+
+import (
+	"bytes"
+	"net"
+	"regexp"
+)
+
+// Category is a human-readable classification of a string's content.
+type Category string
+
+// Classification categories.
+const (
+	CategoryURL         Category = "URL"
+	CategoryEmail       Category = "Email"
+	CategoryIPv4        Category = "IPv4"
+	CategoryIPv6        Category = "IPv6"
+	CategoryUUID        Category = "UUID"
+	CategoryPathWindows Category = "WinPath"
+	CategoryPathUnix    Category = "UnixPath"
+	CategoryDomain      Category = "Domain"
+	CategoryHex         Category = "Hex"
+	CategoryBase64      Category = "Base64"
+)
+
+// Result holds the triage analysis of a single string.
+type Result struct {
+	// Entropy is the Shannon entropy (bits/byte) of the trimmed string.
+	Entropy float64
+	// HighEntropy is true when Entropy meets the configured threshold and the
+	// string looks like an opaque token rather than natural-language text.
+	HighEntropy bool
+	// Categories holds the content classification (at most one, first match
+	// wins by priority); empty when nothing matched.
+	Categories []Category
+	// Secrets holds any detected secrets/credentials.
+	Secrets []SecretFinding
+}
+
+// Interesting reports whether the result is worth surfacing in --secrets mode:
+// it contains a detected secret or qualifies as a high-entropy blob.
+func (r Result) Interesting() bool {
+	return len(r.Secrets) > 0 || r.HighEntropy
+}
+
+// Anchored category patterns. RE2 guarantees linear-time evaluation.
+var (
+	reURL        = regexp.MustCompile(`^(?:https?|ftps?|ssh|file|s3|git)://[^\s]+$`)
+	reEmail      = regexp.MustCompile(`^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$`)
+	reUUID       = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	rePathWin    = regexp.MustCompile(`^[A-Za-z]:\\[^\x00\r\n]*$`)
+	rePathUnix   = regexp.MustCompile(`^/(?:[^/\x00\s]+/)+[^/\x00\s]*$`)
+	// TLD restricted to lowercase letters: embedded real domains are virtually
+	// always lowercase, whereas mixed-case junk (e.g. DEX identifiers like
+	// "TE.An", "qY.Ze") would otherwise match and flood domain classification.
+	reDomain     = regexp.MustCompile(`^(?:[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?\.)+[a-z]{2,24}$`)
+	reHex        = regexp.MustCompile(`^(?:[0-9a-f]{16,}|[0-9A-F]{16,})$`)
+	reBase64     = regexp.MustCompile(`^[A-Za-z0-9+/]{16,}={0,2}$`)
+	reNumericIsh = regexp.MustCompile(`^[0-9a-fA-F.:%]+$`)
+)
+
+// Classify analyzes a string and returns its entropy, content category, and any
+// detected secrets. minEntropy is the threshold (bits/byte) above which an
+// opaque token is flagged as high-entropy; pass 0 to disable that flag.
+func Classify(str []byte, minEntropy float64) Result {
+	trimmed := bytes.TrimSpace(str)
+
+	r := Result{Entropy: Entropy(trimmed)}
+
+	cat, hasCat := classifyCategory(trimmed)
+	if hasCat {
+		r.Categories = append(r.Categories, cat)
+	}
+
+	r.Secrets = detectSecrets(str)
+
+	// High-entropy flags opaque blobs. Suppress it for recognized structural
+	// content (URLs, paths, domains, IPs, ...) which is rarely secret material;
+	// keep it when uncategorized or when the bytes are an opaque Hex/Base64 blob
+	// (the shapes key material typically takes).
+	if minEntropy > 0 && r.Entropy >= minEntropy && isTokenLike(trimmed) {
+		if !hasCat || cat == CategoryHex || cat == CategoryBase64 {
+			r.HighEntropy = true
+		}
+	}
+
+	return r
+}
+
+// classifyCategory returns the highest-priority category matching the string.
+func classifyCategory(b []byte) (Category, bool) {
+	switch {
+	case reURL.Match(b):
+		return CategoryURL, true
+	case reEmail.Match(b):
+		return CategoryEmail, true
+	}
+
+	// IP addresses: use net.ParseIP for correctness, gated by a cheap pre-check.
+	if reNumericIsh.Match(b) && (bytes.IndexByte(b, '.') >= 0 || bytes.IndexByte(b, ':') >= 0) {
+		if ip := net.ParseIP(string(b)); ip != nil {
+			if ip.To4() != nil {
+				return CategoryIPv4, true
+			}
+			return CategoryIPv6, true
+		}
+	}
+
+	switch {
+	case reUUID.Match(b):
+		return CategoryUUID, true
+	case rePathWin.Match(b):
+		return CategoryPathWindows, true
+	case rePathUnix.Match(b):
+		return CategoryPathUnix, true
+	case reDomain.Match(b):
+		return CategoryDomain, true
+	case reHex.Match(b) && len(b)%2 == 0:
+		return CategoryHex, true
+	case reBase64.Match(b):
+		return CategoryBase64, true
+	}
+
+	return "", false
+}
+
+// minSecretLen is a lower bound on the length of any string that could contain
+// a secret: the shortest detector (Slack token) needs ~14 bytes, so strings
+// below this threshold are skipped without running the (relatively expensive)
+// regex scan. Short strings dominate real binaries, so this is a meaningful win.
+const minSecretLen = 12
+
+// detectSecrets runs every secret rule against the string, applying entropy
+// gating where configured.
+func detectSecrets(str []byte) []SecretFinding {
+	if len(str) < minSecretLen {
+		return nil
+	}
+
+	var findings []SecretFinding
+	for _, rule := range secretRules {
+		loc := rule.re.FindIndex(str)
+		if loc == nil {
+			continue
+		}
+		match := str[loc[0]:loc[1]]
+		if rule.minEntropy > 0 && Entropy(match) < rule.minEntropy {
+			continue
+		}
+		findings = append(findings, SecretFinding{
+			Rule:     rule.name,
+			Severity: rule.severity,
+			Match:    string(match),
+		})
+	}
+	return findings
+}
+
+// isTokenLike reports whether b looks like an opaque token: long enough and
+// free of whitespace/control characters (which would indicate prose).
+func isTokenLike(b []byte) bool {
+	if len(b) < 20 {
+		return false
+	}
+	for _, c := range b {
+		if c <= ' ' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/triage/entropy.go
+++ b/internal/triage/entropy.go
@@ -1,0 +1,36 @@
+// Package triage provides security-triage analysis of extracted strings:
+// Shannon entropy scoring, content classification (URL/IP/email/path/etc.),
+// and secret/credential detection.
+//
+// The package has no dependencies on other internal packages so it can be
+// reused by the printer (text output), JSON output, and statistics modes
+// without creating import cycles.
+package triage
+
+import "math"
+
+// Entropy returns the Shannon entropy of data in bits per byte, a value in the
+// range [0, 8]. Higher values indicate more randomness: natural-language text
+// typically scores ~4.0-4.5, base64-encoded data ~6, and cryptographic key
+// material approaches 8.
+func Entropy(data []byte) float64 {
+	if len(data) == 0 {
+		return 0
+	}
+
+	var counts [256]int
+	for _, b := range data {
+		counts[b]++
+	}
+
+	n := float64(len(data))
+	var h float64
+	for _, c := range counts {
+		if c == 0 {
+			continue
+		}
+		p := float64(c) / n
+		h -= p * math.Log2(p)
+	}
+	return h
+}

--- a/internal/triage/rules.go
+++ b/internal/triage/rules.go
@@ -1,0 +1,85 @@
+package triage
+
+import "regexp"
+
+// Severity classifies how serious a secret finding is.
+type Severity string
+
+// Severity levels for secret findings.
+const (
+	SeverityHigh   Severity = "HIGH"
+	SeverityMedium Severity = "MEDIUM"
+	SeverityLow    Severity = "LOW"
+)
+
+// SecretFinding describes a single secret detected inside a string.
+type SecretFinding struct {
+	Rule     string   `json:"rule"`
+	Severity Severity `json:"severity"`
+	Match    string   `json:"match"`
+}
+
+// secretRule is a precompiled detector for one class of secret.
+//
+// All patterns are compiled once at package initialization (never per-string),
+// mirroring the CompilePatterns discipline in internal/extractor/filter.go.
+// Go's regexp engine (RE2) guarantees linear-time matching, so these patterns
+// are inherently free of catastrophic-backtracking (ReDoS) risk.
+type secretRule struct {
+	name     string
+	severity Severity
+	re       *regexp.Regexp
+	// minEntropy, when > 0, gates the rule: a candidate match whose Shannon
+	// entropy is below this threshold is rejected as a likely false positive.
+	minEntropy float64
+}
+
+// secretRules is the ordered set of secret detectors applied to every string
+// in triage mode. Patterns are intentionally anchored on recognizable prefixes
+// to keep false positives low.
+var secretRules = []secretRule{
+	{
+		name:     "AWS Access Key",
+		severity: SeverityHigh,
+		re:       regexp.MustCompile(`\b(?:AKIA|ASIA|AGPA|AIDA|AROA|ANPA|ANVA|A3T[A-Z0-9])[A-Z0-9]{16}\b`),
+	},
+	{
+		name:     "PEM Private Key",
+		severity: SeverityHigh,
+		re:       regexp.MustCompile(`-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY-----`),
+	},
+	{
+		name:     "GitHub Token",
+		severity: SeverityHigh,
+		re:       regexp.MustCompile(`\bgh[posru]_[A-Za-z0-9]{36,}\b`),
+	},
+	{
+		name:     "Slack Token",
+		severity: SeverityHigh,
+		re:       regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}\b`),
+	},
+	{
+		name:     "Google API Key",
+		severity: SeverityHigh,
+		re:       regexp.MustCompile(`\bAIza[0-9A-Za-z_\-]{35}\b`),
+	},
+	{
+		name:     "Stripe Key",
+		severity: SeverityHigh,
+		re:       regexp.MustCompile(`\b[sprk]k_(?:test|live)_[A-Za-z0-9]{16,}\b`),
+	},
+	{
+		name:     "JSON Web Token",
+		severity: SeverityMedium,
+		re:       regexp.MustCompile(`\beyJ[A-Za-z0-9_\-]+\.eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+`),
+	},
+	{
+		name:     "Generic Secret",
+		severity: SeverityMedium,
+		// key-like name, an actual assignment operator (: or =, optionally
+		// quoted/spaced), then a sufficiently long value. Requiring : or =
+		// avoids matching prose such as "password authentication is ...".
+		re:         regexp.MustCompile(`(?i)(?:api[_-]?key|secret|token|password|passwd|access[_-]?key)["']?\s*[:=]\s*["']?[A-Za-z0-9/+=_\-]{12,}`),
+		minEntropy: 3.5,
+	},
+}

--- a/internal/triage/triage_test.go
+++ b/internal/triage/triage_test.go
@@ -1,0 +1,213 @@
+package triage
+
+import (
+	"math"
+	"testing"
+)
+
+func TestEntropy(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want float64
+		tol  float64
+	}{
+		{"empty", "", 0, 0},
+		{"single byte repeated", "aaaaaaaa", 0, 0.0001},
+		{"two equiprobable symbols", "abababab", 1.0, 0.0001},
+		{"four equiprobable symbols", "abcdabcd", 2.0, 0.0001},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Entropy([]byte(tt.data))
+			if math.Abs(got-tt.want) > tt.tol {
+				t.Errorf("Entropy(%q) = %v, want %v", tt.data, got, tt.want)
+			}
+		})
+	}
+
+	// 256 distinct bytes should approach the maximum of 8 bits/byte.
+	all := make([]byte, 256)
+	for i := range all {
+		all[i] = byte(i)
+	}
+	if got := Entropy(all); math.Abs(got-8.0) > 0.0001 {
+		t.Errorf("Entropy(all 256 bytes) = %v, want 8", got)
+	}
+}
+
+func TestClassifyCategory(t *testing.T) {
+	tests := []struct {
+		in   string
+		want Category
+	}{
+		{"https://example.com/path?q=1", CategoryURL},
+		{"s3://bucket/key", CategoryURL},
+		{"user.name@example.co.uk", CategoryEmail},
+		{"10.0.0.5", CategoryIPv4},
+		{"255.255.255.0", CategoryIPv4},
+		{"2001:db8::1", CategoryIPv6},
+		{"550e8400-e29b-41d4-a716-446655440000", CategoryUUID},
+		{`C:\Windows\System32\drivers`, CategoryPathWindows},
+		{"/usr/local/bin/txtr", CategoryPathUnix},
+		{"api.github.com", CategoryDomain},
+		{"deadbeefcafebabe1234", CategoryHex},
+		{"TWFuIGlzIGRpc3Rpbmd1aXNoZWQ=", CategoryBase64},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			cat, ok := classifyCategory([]byte(tt.in))
+			if !ok {
+				t.Fatalf("classifyCategory(%q) returned no category, want %q", tt.in, tt.want)
+			}
+			if cat != tt.want {
+				t.Errorf("classifyCategory(%q) = %q, want %q", tt.in, cat, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyCategoryNegatives(t *testing.T) {
+	// Plain prose and short tokens should not be classified.
+	for _, in := range []string{"hello world", "a short string", "not/a path", "999.999.999.999"} {
+		if cat, ok := classifyCategory([]byte(in)); ok {
+			t.Errorf("classifyCategory(%q) = %q, want no match", in, cat)
+		}
+	}
+}
+
+func TestDetectSecrets(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		rule string
+	}{
+		{"aws", "AKIAIOSFODNN7EXAMPLE", "AWS Access Key"},
+		{"pem", "-----BEGIN RSA PRIVATE KEY-----", "PEM Private Key"},
+		{"github", "ghp_" + repeat("a", 36), "GitHub Token"},
+		{"slack", "xoxb-123456789012-abcdefghijkl", "Slack Token"},
+		{"stripe", "sk_live_" + repeat("A", 20), "Stripe Key"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := detectSecrets([]byte(tt.in))
+			if len(findings) == 0 {
+				t.Fatalf("detectSecrets(%q) found nothing, want rule %q", tt.in, tt.rule)
+			}
+			found := false
+			for _, f := range findings {
+				if f.Rule == tt.rule {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("detectSecrets(%q) = %+v, want rule %q", tt.in, findings, tt.rule)
+			}
+		})
+	}
+}
+
+func TestDetectSecretsNoFalsePositives(t *testing.T) {
+	for _, in := range []string{"hello world", "the quick brown fox", "AKIA-too-short"} {
+		if findings := detectSecrets([]byte(in)); len(findings) != 0 {
+			t.Errorf("detectSecrets(%q) = %+v, want none", in, findings)
+		}
+	}
+}
+
+func TestClassifyHighEntropy(t *testing.T) {
+	// A long random-looking token above threshold is high-entropy.
+	token := "gB7x9K2pQ4rT6yU8wA1zC3vN5mL0jH" // mixed-case alnum, no spaces
+	r := Classify([]byte(token), 4.0)
+	if !r.HighEntropy {
+		t.Errorf("Classify(%q).HighEntropy = false (entropy=%v), want true", token, r.Entropy)
+	}
+	if !r.Interesting() {
+		t.Errorf("Classify(%q).Interesting() = false, want true", token)
+	}
+
+	// Prose with spaces must not be high-entropy regardless of threshold.
+	prose := "the quick brown fox jumps over the lazy dog"
+	if Classify([]byte(prose), 0.5).HighEntropy {
+		t.Errorf("Classify(prose).HighEntropy = true, want false")
+	}
+
+	// Disabled threshold (0) never flags high-entropy.
+	if Classify([]byte(token), 0).HighEntropy {
+		t.Errorf("Classify with minEntropy=0 flagged high-entropy, want false")
+	}
+}
+
+// TestDogfoodRegressions covers false positives found by running triage over a
+// real-world corpus (system binaries, firmware, APKs/DEX).
+func TestDogfoodRegressions(t *testing.T) {
+	t.Run("prose is not a generic secret", func(t *testing.T) {
+		// Found in /usr/bin/ssh: prose with "password " + word matched the old
+		// generic rule because it allowed a bare space as the separator.
+		prose := "Password authentication is disabled to avoid man-in-the-middle attacks."
+		if f := detectSecrets([]byte(prose)); len(f) != 0 {
+			t.Errorf("detectSecrets(prose) = %+v, want none", f)
+		}
+		// A real assignment must still match.
+		if f := detectSecrets([]byte("password=hunter2hunter2")); len(f) == 0 {
+			t.Errorf("detectSecrets(real assignment) found nothing, want a match")
+		}
+		if f := detectSecrets([]byte(`api_key: "AKIAabcdef0123456789"`)); len(f) == 0 {
+			t.Errorf("detectSecrets(api_key assignment) found nothing, want a match")
+		}
+	})
+
+	t.Run("mixed-case identifiers are not domains", func(t *testing.T) {
+		// Found in DEX string tables: mangled identifiers matched the domain TLD.
+		for _, junk := range []string{"qY.Ze", "TE.An", "Tr.Ir", "T0.OTB.Oq"} {
+			if cat, ok := classifyCategory([]byte(junk)); ok && cat == CategoryDomain {
+				t.Errorf("classifyCategory(%q) = Domain, want not-a-domain", junk)
+			}
+		}
+		// Real lowercase domains still classify.
+		for _, d := range []string{"api.github.com", "example.co.uk", "downloads.openwrt.org"} {
+			if cat, ok := classifyCategory([]byte(d)); !ok || cat != CategoryDomain {
+				t.Errorf("classifyCategory(%q) = (%q,%v), want Domain", d, cat, ok)
+			}
+		}
+	})
+
+	t.Run("structural content is not high-entropy", func(t *testing.T) {
+		// Found in /usr/bin/ssh: long build paths flooded HIGH-ENT output.
+		path := "/AppleInternal/Library/BuildRoots/4~CNqOugDnhI02cZCCCbihSM9XQTugjRCpEt/Library"
+		if r := Classify([]byte(path), 4.5); r.HighEntropy {
+			t.Errorf("Classify(path).HighEntropy = true, want false (entropy=%.2f)", r.Entropy)
+		}
+		// An opaque base64-shaped blob of similar entropy should still flag.
+		blob := "z8PxKAjRS9di0bBYU17OsoETJW4xQpL9mNvCdEf="
+		if r := Classify([]byte(blob), 4.5); !r.HighEntropy {
+			t.Errorf("Classify(base64 blob).HighEntropy = false, want true (entropy=%.2f)", r.Entropy)
+		}
+	})
+}
+
+func repeat(s string, n int) string {
+	out := make([]byte, 0, len(s)*n)
+	for range n {
+		out = append(out, s...)
+	}
+	return string(out)
+}
+
+func FuzzClassify(f *testing.F) {
+	seeds := []string{
+		"", "https://example.com", "AKIAIOSFODNN7EXAMPLE",
+		"-----BEGIN RSA PRIVATE KEY-----", "10.0.0.5", "2001:db8::1",
+		"deadbeef", "C:\\Windows", "/usr/bin", "user@example.com",
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s), 4.5)
+	}
+	f.Fuzz(func(t *testing.T, data []byte, minEntropy float64) {
+		// Must never panic and must return a sane entropy value.
+		r := Classify(data, minEntropy)
+		if r.Entropy < 0 || r.Entropy > 8.0001 {
+			t.Errorf("entropy out of range: %v for %q", r.Entropy, data)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Two additive features that extend `txtr` from a plain `strings` clone into a firmware/malware triage tool.

### 🔍 Security triage (`internal/triage`)
- `--triage` tags each string by detected **secret**, **high-entropy** blob, or **content category** (URL/email/IPv4/IPv6/domain/path/hex/base64/UUID)
- `--secrets` surfaces only secrets + high-entropy strings; `--min-entropy` tunes the threshold (default 4.5)
- Shannon entropy + precompiled RE2 secret rules (AWS/PEM/GitHub/Slack/Stripe/Google/JWT/generic assignment) with entropy gating
- Composes with `-j` (adds `entropy`/`categories`/`secrets` JSON fields) and `--stats` (category/secret/high-entropy rollup)
- Pure analysis core (no internal deps) reused by `printer` and `stats` without import cycles; strings <12B skip the secret scan

### 📦 Archive recursion (`internal/archive`)
- `-r`/`--recurse` descends into **zip/apk/jar/ipa, tar, gzip, bzip2, xz, zstd, ar/deb** containers, scanning every contained file
- Virtual paths with `!/` separators, e.g. `pkg.deb!/data.tar!/usr/bin/htop`
- Decompression-bomb guards: `--max-depth` (default 8), `--max-decompressed-size` (default 2 GiB); top-level zip uses random access (no full buffering)
- Single `extractFile()` routing seam composes recursion with text/triage/stats/JSON in sequential + parallel paths
- Pure-Go xz/zstd decoders keep the **zero-CGO static build** (binary ~3.8MB → ~7MB)

## Dogfooding
Validated on a corpus of real APKs, a `.deb` (xz members), OpenWrt firmware, and Mach-O binaries. Recursion exposed **8,013 domains + 92 URLs + IPs/emails** hidden inside an APK's compressed DEX, and descended `ar → data.tar.xz → ELF` in the `.deb`. Triage false-positive fixes (prose-as-secret, mixed-case "domains", path high-entropy noise) came directly from this dogfooding and are covered by regression tests.

## Testing
- `go test -race ./...` — all pass; new archive unit tests + `FuzzWalkStream`, triage unit/regression tests + `FuzzClassify`
- triage and plain-vs-triage benchmarks added
- `go vet`, `golangci-lint` (0 issues), `goreleaser check`, CGO=0 static build — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)