### PR TITLE
feat: thread context cancellation through extraction (archives v0.2.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,14 +60,14 @@ txtr/
 ```
 
 **Core Components:**
-- `extractor.ExtractStrings()`: Dispatches to encoding-specific extractors
+- `extractor.ExtractStrings()`: Dispatches to encoding-specific extractors; takes a `context.Context` and returns `error` (returns `ctx.Err()` on cancel). Streaming loops wrap the reader in `ctxReader` (polls ctx once per buffer refill — no per-byte cost); byte-slice/mmap loops poll ctx once per 64 KiB chunk (`ctxChunk`) with a branch-free inner loop
 - `printer.PrintString()`: Formats output with colors/offsets
 - `printer.JSONPrinter`: Collector pattern for structured output
 - `printer.TriagePrinter`: Annotated triage output (tags each string by secret/entropy/category)
 - `stats.Statistics`: Aggregates metrics for `--stats` mode (incl. triage rollup)
 - `triage.Classify()`: Pure analysis (entropy + classification + secret rules); no internal deps, so `printer` and `stats` both reuse it without import cycles
-- `archive.Walk()`: Recurses archives/compressed containers, emitting each leaf file as a stream (`!/`-separated virtual paths) with depth + decompressed-size bomb guards; depends only on stdlib + pure-Go xz/zstd
-- `extractFile()` (cmd/txtr): single routing seam used by every mode — recursion > data-only > whole-file — so `--recurse` composes with text/triage/stats/JSON
+- `archives.Walk(ctx, ...)`: Recurses archives/compressed containers, emitting each leaf file as a stream (`!/`-separated virtual paths) with depth + decompressed-size bomb guards; cancellable via ctx (observed between members and mid-stream); depends only on stdlib + pure-Go xz/zstd
+- `extractFile()` (cmd/txtr): single routing seam used by every mode — recursion > data-only > whole-file — so `--recurse` composes with text/triage/stats/JSON. Takes `ctx`; `main()` derives it from `signal.NotifyContext` (SIGINT/SIGTERM). Worker pools select on `ctx.Done()`; `reportErr` suppresses cancellation noise so the central handler prints one `strings: interrupted` and exits 130
 
 **Key Patterns:**
 - Dependency injection: printFunc callback for testability
@@ -93,6 +93,7 @@ txtr/
 **Statistics Mode:** `--stats` for quick triage (encoding dist, length buckets, top-5 longest)
 **Security Triage:** `--triage`/`--secrets` for entropy scoring, content classification, and secret detection (composes with `-j` and `--stats`)
 **Archive Recursion:** `--recurse` descends into zip/apk/tar/gz/bz2/xz/zst/deb containers, scanning each member with `!/` virtual paths and decompression-bomb guards
+**Cancellation:** SIGINT (Ctrl-C)/SIGTERM cancels a `context.Context` threaded through every mode; extraction loops, worker pools, and archive walks abort promptly (clean `strings: interrupted`, exit 130)
 **JSON Output:** `--json` for automation (works with jq)
 **Color Output:** Auto TTY detection, respects NO_COLOR env var
 **Fuzzing:** 11 fuzz targets (string extraction, binary parsing, filtering, triage classification, archive walking) with CVE coverage
@@ -120,7 +121,7 @@ txtr/
 
 ## Dependencies
 
-**Runtime:** Kong v1.14.0, golang.org/x/exp/mmap, ulikunitz/xz + klauspost/compress (pure-Go xz/zstd for `--recurse`), Go 1.26 stdlib
+**Runtime:** Kong v1.15.0, richardwooding/archives v0.2.0 (context-cancellable archive walking) + triage v0.1.0, golang.org/x/exp/mmap, ulikunitz/xz + klauspost/compress (pure-Go xz/zstd for `--recurse`), Go 1.26 stdlib
 **Build:** GoReleaser v2.12.7, Ko (containerized), golangci-lint v2.9.0
 **Key:** Zero CGO, fully static binaries (~7MB; grew from ~3.8MB with the pure-Go zstd/xz decoders added for `--recurse`)
 

--- a/cmd/txtr/main.go
+++ b/cmd/txtr/main.go
@@ -4,12 +4,16 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"regexp"
 	"runtime"
 	"sync"
+	"syscall"
 
 	"github.com/alecthomas/kong"
 	"github.com/richardwooding/archives"
@@ -19,6 +23,21 @@ import (
 	"github.com/richardwooding/txtr/internal/stats"
 )
 
+// reportErr prints a per-file error to stderr unless it is a context
+// cancellation (which is reported once, centrally, as "strings: interrupted").
+// It returns true when err is a cancellation, signalling callers to stop.
+func reportErr(filename string, err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if filename != "" {
+		fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
+	} else {
+		fmt.Fprintf(os.Stderr, "strings: %v\n", err)
+	}
+	return false
+}
+
 // printFunc is the callback every output mode supplies to receive extracted
 // strings: (string bytes, source path, byte offset within the source, config).
 type printFunc = func([]byte, string, int64, extractor.Config)
@@ -27,18 +46,17 @@ type printFunc = func([]byte, string, int64, extractor.Config)
 // based on config precedence: recursion (archive walk) > data-only (binary
 // sections) > whole-file scan. Extracted strings are delivered to fn. Used by
 // every output mode so recursion composes with text/triage/stats/JSON output.
-func extractFile(filename string, config extractor.Config, fn printFunc) error {
+func extractFile(ctx context.Context, filename string, config extractor.Config, fn printFunc) error {
 	if config.Recursive {
 		opts := archives.Options{MaxDepth: config.RecurseMaxDepth, MaxBytes: config.RecurseMaxBytes}
-		return archives.Walk(filename, opts, func(vpath string, r io.Reader) error {
-			extractor.ExtractStrings(r, vpath, config, fn)
-			return nil
+		return archives.Walk(ctx, filename, opts, func(wctx context.Context, vpath string, r io.Reader) error {
+			return extractor.ExtractStrings(wctx, r, vpath, config, fn)
 		})
 	}
 	if config.ScanDataOnly {
-		return extractFileWithBinaryParsing(filename, config, fn)
+		return extractFileWithBinaryParsing(ctx, filename, config, fn)
 	}
-	return extractor.ExtractStringsFromFile(filename, config, fn)
+	return extractor.ExtractStringsFromFile(ctx, filename, config, fn)
 }
 
 // Build information (set by goreleaser via ldflags)
@@ -243,46 +261,63 @@ func main() {
 		workers = runtime.NumCPU()
 	}
 
+	// Cancellable context wired to Ctrl-C (SIGINT) and SIGTERM so long scans,
+	// worker pools, and archive walks can be aborted promptly.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	// Process files or stdin
 	if cli.Stats {
 		// Statistics output mode
-		processWithStats(cli.Files, workers, config, cli.StatsPerFile)
+		processWithStats(ctx, cli.Files, workers, config, cli.StatsPerFile)
 	} else if cli.JSON {
 		// JSON output mode
-		processWithJSON(cli.Files, workers, config)
+		processWithJSON(ctx, cli.Files, workers, config)
 	} else if cli.Triage {
 		// Security triage output mode
-		processWithTriage(cli.Files, workers, config)
+		processWithTriage(ctx, cli.Files, workers, config)
 	} else if len(cli.Files) == 0 {
 		// Read from stdin
-		extractor.ExtractStrings(os.Stdin, "", config, printer.PrintString)
+		if err := extractor.ExtractStrings(ctx, os.Stdin, "", config, printer.PrintString); err != nil {
+			reportErr("", err)
+		}
 	} else if len(cli.Files) > 1 && workers > 1 {
 		// Process multiple files in parallel
-		processFilesParallel(cli.Files, workers, config)
+		processFilesParallel(ctx, cli.Files, workers, config)
 	} else {
 		// Process each file sequentially (single file or workers=1)
 		for _, filename := range cli.Files {
-			if err := extractFile(filename, config, printer.PrintString); err != nil {
-				fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
+			if err := extractFile(ctx, filename, config, printer.PrintString); err != nil {
+				if reportErr(filename, err) {
+					break
+				}
 				continue
 			}
 		}
+	}
+
+	// Single, central cancellation notice + conventional 128+SIGINT exit code.
+	if ctx.Err() != nil {
+		fmt.Fprintln(os.Stderr, "strings: interrupted")
+		os.Exit(130)
 	}
 }
 
 // processWithJSON processes files or stdin with JSON output
 // Supports parallel processing for multiple files with automatic error handling
-func processWithJSON(files []string, workers int, config extractor.Config) {
+func processWithJSON(ctx context.Context, files []string, workers int, config extractor.Config) {
 	var jsonPrinter *printer.JSONPrinter
 
 	if len(files) == 0 {
 		// Read from stdin
 		jsonPrinter = printer.NewJSONPrinter(config, os.Stdout)
 		jsonPrinter.SetFileInfo("", "", nil)
-		extractor.ExtractStrings(os.Stdin, "", config, jsonPrinter.PrintString)
+		if err := extractor.ExtractStrings(ctx, os.Stdin, "", config, jsonPrinter.PrintString); err != nil {
+			reportErr("", err)
+		}
 	} else if len(files) > 1 && workers > 1 {
 		// Process multiple files in parallel
-		jsonPrinter = processFilesParallelJSON(files, workers, config)
+		jsonPrinter = processFilesParallelJSON(ctx, files, workers, config)
 	} else {
 		// Process files sequentially (single file or workers=1)
 		jsonPrinter = printer.NewJSONPrinter(config, os.Stdout)
@@ -290,19 +325,23 @@ func processWithJSON(files []string, workers int, config extractor.Config) {
 		for _, filename := range files {
 			if config.Recursive {
 				jsonPrinter.SetFileInfo(filename, "archive", nil)
-				if err := extractFile(filename, config, jsonPrinter.PrintString); err != nil {
-					fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
+				if err := extractFile(ctx, filename, config, jsonPrinter.PrintString); err != nil {
+					if reportErr(filename, err) {
+						break
+					}
 					jsonPrinter.AddFileResult(filename, "archive", nil, nil, err)
 					continue
 				}
 			} else if config.ScanDataOnly {
 				// Parse binary and extract from data sections
-				processFileWithBinaryParsingJSON(filename, config, jsonPrinter)
+				processFileWithBinaryParsingJSON(ctx, filename, config, jsonPrinter)
 			} else {
 				// Regular full-file scanning with automatic mmap optimization
 				jsonPrinter.SetFileInfo(filename, "", nil)
-				if err := extractor.ExtractStringsFromFile(filename, config, jsonPrinter.PrintString); err != nil {
-					fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
+				if err := extractor.ExtractStringsFromFile(ctx, filename, config, jsonPrinter.PrintString); err != nil {
+					if reportErr(filename, err) {
+						break
+					}
 					// Add error result to JSON
 					jsonPrinter.AddFileResult(filename, "", nil, nil, err)
 					continue
@@ -319,7 +358,7 @@ func processWithJSON(files []string, workers int, config extractor.Config) {
 }
 
 // processFileWithBinaryParsingJSON handles binary parsing with JSON output
-func processFileWithBinaryParsingJSON(filename string, config extractor.Config, jsonPrinter *printer.JSONPrinter) {
+func processFileWithBinaryParsingJSON(ctx context.Context, filename string, config extractor.Config, jsonPrinter *printer.JSONPrinter) {
 	// Determine format
 	var format binary.Format
 	var err error
@@ -364,7 +403,9 @@ func processFileWithBinaryParsingJSON(filename string, config extractor.Config, 
 		}()
 
 		jsonPrinter.SetFileInfo(filename, format.String(), nil)
-		extractor.ExtractStrings(file, filename, config, jsonPrinter.PrintString)
+		if err := extractor.ExtractStrings(ctx, file, filename, config, jsonPrinter.PrintString); err != nil {
+			reportErr(filename, err)
+		}
 		return
 	}
 
@@ -390,18 +431,24 @@ func processFileWithBinaryParsingJSON(filename string, config extractor.Config, 
 			}
 		}()
 
-		extractor.ExtractStrings(file, filename, config, jsonPrinter.PrintString)
+		if err := extractor.ExtractStrings(ctx, file, filename, config, jsonPrinter.PrintString); err != nil {
+			reportErr(filename, err)
+		}
 		return
 	}
 
 	// Extract strings from each data section
 	for _, section := range sections {
-		extractor.ExtractFromSection(section.Data, section.Name, section.Offset, filename, config, jsonPrinter.PrintString)
+		if err := extractor.ExtractFromSection(ctx, section.Data, section.Name, section.Offset, filename, config, jsonPrinter.PrintString); err != nil {
+			if reportErr(filename, err) {
+				break
+			}
+		}
 	}
 }
 
 // processFilesParallel processes multiple files in parallel using a worker pool
-func processFilesParallel(filenames []string, workers int, config extractor.Config) {
+func processFilesParallel(ctx context.Context, filenames []string, workers int, config extractor.Config) {
 	// Create channels for jobs and results
 	jobs := make(chan job, len(filenames))
 	results := make(chan result, len(filenames))
@@ -410,27 +457,42 @@ func processFilesParallel(filenames []string, workers int, config extractor.Conf
 	var wg sync.WaitGroup
 	for range workers {
 		wg.Go(func() {
-			for j := range jobs {
-				// Create a buffer to capture output for this file
-				var buf bytes.Buffer
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case j, ok := <-jobs:
+					if !ok {
+						return
+					}
+					// Create a buffer to capture output for this file
+					var buf bytes.Buffer
 
-				// Create a print function that writes to the buffer
-				printToBuf := func(str []byte, filename string, offset int64, cfg extractor.Config) {
-					printer.PrintStringToWriter(&buf, str, filename, offset, cfg)
+					// Create a print function that writes to the buffer
+					printToBuf := func(str []byte, filename string, offset int64, cfg extractor.Config) {
+						printer.PrintStringToWriter(&buf, str, filename, offset, cfg)
+					}
+
+					// Process the file (recursion/data-only/whole-file)
+					err := extractFile(ctx, j.filename, config, printToBuf)
+
+					// Send result
+					select {
+					case results <- result{index: j.index, output: buf.String(), err: err}:
+					case <-ctx.Done():
+						return
+					}
 				}
-
-				// Process the file (recursion/data-only/whole-file)
-				err := extractFile(j.filename, config, printToBuf)
-
-				// Send result
-				results <- result{index: j.index, output: buf.String(), err: err}
 			}
 		})
 	}
 
 	// Send jobs
 	for i, filename := range filenames {
-		jobs <- job{filename: filename, index: i}
+		select {
+		case jobs <- job{filename: filename, index: i}:
+		case <-ctx.Done():
+		}
 	}
 	close(jobs)
 
@@ -449,7 +511,7 @@ func processFilesParallel(filenames []string, workers int, config extractor.Conf
 	// Print results in order
 	for _, r := range outputs {
 		if r.err != nil {
-			fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filenames[r.index], r.err)
+			reportErr(filenames[r.index], r.err)
 			continue
 		}
 		fmt.Print(r.output)
@@ -457,7 +519,7 @@ func processFilesParallel(filenames []string, workers int, config extractor.Conf
 }
 
 // processFilesParallelJSON processes multiple files in parallel for JSON output
-func processFilesParallelJSON(filenames []string, workers int, config extractor.Config) *printer.JSONPrinter {
+func processFilesParallelJSON(ctx context.Context, filenames []string, workers int, config extractor.Config) *printer.JSONPrinter {
 	// Create channels for jobs and results
 	jobs := make(chan job, len(filenames))
 	results := make(chan jsonFileResult, len(filenames))
@@ -466,7 +528,18 @@ func processFilesParallelJSON(filenames []string, workers int, config extractor.
 	var wg sync.WaitGroup
 	for range workers {
 		wg.Go(func() {
-			for j := range jobs {
+			for {
+				var j job
+				var ok bool
+				select {
+				case <-ctx.Done():
+					return
+				case j, ok = <-jobs:
+					if !ok {
+						return
+					}
+				}
+
 				// Create a temporary JSON printer for this file
 				var buf bytes.Buffer
 				tempPrinter := printer.NewJSONPrinter(config, &buf)
@@ -478,9 +551,9 @@ func processFilesParallelJSON(filenames []string, workers int, config extractor.
 
 				if config.Recursive {
 					tempPrinter.SetFileInfo(j.filename, "archive", nil)
-					err = extractFile(j.filename, config, tempPrinter.PrintString)
+					err = extractFile(ctx, j.filename, config, tempPrinter.PrintString)
 					if err != nil {
-						results <- jsonFileResult{index: j.index, filename: j.filename, err: err}
+						sendJSONResult(ctx, results, jsonFileResult{index: j.index, filename: j.filename, err: err})
 						continue
 					}
 					tempPrinter.FinalizeCurrentFile()
@@ -492,17 +565,17 @@ func processFilesParallelJSON(filenames []string, workers int, config extractor.
 					}
 				} else if config.ScanDataOnly {
 					// Process with binary parsing
-					format, sections, strings, err = processFileForJSON(j.filename, config)
+					format, sections, strings, err = processFileForJSON(ctx, j.filename, config)
 				} else {
 					// Regular full-file scanning with automatic mmap optimization
 					tempPrinter.SetFileInfo(j.filename, "", nil)
-					err = extractor.ExtractStringsFromFile(j.filename, config, tempPrinter.PrintString)
+					err = extractor.ExtractStringsFromFile(ctx, j.filename, config, tempPrinter.PrintString)
 					if err != nil {
-						results <- jsonFileResult{
+						sendJSONResult(ctx, results, jsonFileResult{
 							index:    j.index,
 							filename: j.filename,
 							err:      err,
-						}
+						})
 						continue
 					}
 
@@ -520,21 +593,24 @@ func processFilesParallelJSON(filenames []string, workers int, config extractor.
 				if strings == nil {
 					strings = make([]printer.StringResult, 0)
 				}
-				results <- jsonFileResult{
+				sendJSONResult(ctx, results, jsonFileResult{
 					index:    j.index,
 					filename: j.filename,
 					format:   format,
 					sections: sections,
 					strings:  strings,
 					err:      err,
-				}
+				})
 			}
 		})
 	}
 
 	// Send jobs
 	for i, filename := range filenames {
-		jobs <- job{filename: filename, index: i}
+		select {
+		case jobs <- job{filename: filename, index: i}:
+		case <-ctx.Done():
+		}
 	}
 	close(jobs)
 
@@ -553,9 +629,15 @@ func processFilesParallelJSON(filenames []string, workers int, config extractor.
 	// Build final JSON output
 	jsonPrinter := printer.NewJSONPrinter(config, os.Stdout)
 	for _, r := range outputs {
+		// Skip jobs a cancelled worker never produced (zero-value entries).
+		if r.filename == "" {
+			continue
+		}
 		if r.err != nil {
-			// Print error to stderr as well
-			fmt.Fprintf(os.Stderr, "strings: %s: %v\n", r.filename, r.err)
+			// Suppress cancellation noise / JSON error entries; report real errors.
+			if reportErr(r.filename, r.err) {
+				continue
+			}
 		}
 		// Add file result (with error if present)
 		jsonPrinter.AddFileResult(r.filename, r.format, r.sections, r.strings, r.err)
@@ -564,8 +646,17 @@ func processFilesParallelJSON(filenames []string, workers int, config extractor.
 	return jsonPrinter
 }
 
+// sendJSONResult delivers a result unless the context is cancelled first,
+// preventing a worker from blocking forever once the collector has stopped.
+func sendJSONResult(ctx context.Context, results chan<- jsonFileResult, r jsonFileResult) {
+	select {
+	case results <- r:
+	case <-ctx.Done():
+	}
+}
+
 // processFileForJSON processes a single file with binary parsing for JSON output
-func processFileForJSON(filename string, config extractor.Config) (string, []string, []printer.StringResult, error) {
+func processFileForJSON(ctx context.Context, filename string, config extractor.Config) (string, []string, []printer.StringResult, error) {
 	// Determine format
 	var format binary.Format
 	var err error
@@ -605,7 +696,9 @@ func processFileForJSON(filename string, config extractor.Config) (string, []str
 		var buf bytes.Buffer
 		tempPrinter := printer.NewJSONPrinter(config, &buf)
 		tempPrinter.SetFileInfo(filename, format.String(), nil)
-		extractor.ExtractStrings(file, filename, config, tempPrinter.PrintString)
+		if err := extractor.ExtractStrings(ctx, file, filename, config, tempPrinter.PrintString); err != nil {
+			return "", nil, nil, err
+		}
 		tempPrinter.FinalizeCurrentFile()
 
 		if len(tempPrinter.FileResults) > 0 {
@@ -636,7 +729,9 @@ func processFileForJSON(filename string, config extractor.Config) (string, []str
 		var buf bytes.Buffer
 		tempPrinter := printer.NewJSONPrinter(config, &buf)
 		tempPrinter.SetFileInfo(filename, format.String(), sectionNames)
-		extractor.ExtractStrings(file, filename, config, tempPrinter.PrintString)
+		if err := extractor.ExtractStrings(ctx, file, filename, config, tempPrinter.PrintString); err != nil {
+			return "", nil, nil, err
+		}
 		tempPrinter.FinalizeCurrentFile()
 
 		if len(tempPrinter.FileResults) > 0 {
@@ -652,7 +747,9 @@ func processFileForJSON(filename string, config extractor.Config) (string, []str
 	tempPrinter.SetFileInfo(filename, format.String(), sectionNames)
 
 	for _, section := range sections {
-		extractor.ExtractFromSection(section.Data, section.Name, section.Offset, filename, config, tempPrinter.PrintString)
+		if err := extractor.ExtractFromSection(ctx, section.Data, section.Name, section.Offset, filename, config, tempPrinter.PrintString); err != nil {
+			return "", nil, nil, err
+		}
 	}
 
 	tempPrinter.FinalizeCurrentFile()
@@ -665,7 +762,7 @@ func processFileForJSON(filename string, config extractor.Config) (string, []str
 }
 
 // processWithStats processes files or stdin with statistics output
-func processWithStats(files []string, workers int, config extractor.Config, perFile bool) {
+func processWithStats(ctx context.Context, files []string, workers int, config extractor.Config, perFile bool) {
 	// stdin case
 	if len(files) == 0 {
 		s := stats.New(config.MinLength)
@@ -676,7 +773,9 @@ func processWithStats(files []string, workers int, config extractor.Config, perF
 			collectFunc = makeFilterTrackingFunc(s, config)
 		}
 
-		extractor.ExtractStrings(os.Stdin, "", config, collectFunc)
+		if err := extractor.ExtractStrings(ctx, os.Stdin, "", config, collectFunc); err != nil {
+			reportErr("", err)
+		}
 		s.Format(os.Stdout, config.ColorMode)
 		return
 	}
@@ -694,20 +793,26 @@ func processWithStats(files []string, workers int, config extractor.Config, perF
 
 			// Process file with binary parsing if needed
 			if config.Recursive {
-				if err := extractFile(filename, config, collectFunc); err != nil {
-					fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
+				if err := extractFile(ctx, filename, config, collectFunc); err != nil {
+					if reportErr(filename, err) {
+						return
+					}
 					continue
 				}
 			} else if config.ScanDataOnly {
-				if err := processFileWithStatsAndBinaryParsing(filename, config, s); err != nil {
-					fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
+				if err := processFileWithStatsAndBinaryParsing(ctx, filename, config, s); err != nil {
+					if reportErr(filename, err) {
+						return
+					}
 					continue
 				}
 			} else {
 				// Use ExtractStringsFromFile with automatic mmap optimization
 				s.SetFileInfo(filename, "", nil)
-				if err := extractor.ExtractStringsFromFile(filename, config, collectFunc); err != nil {
-					fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
+				if err := extractor.ExtractStringsFromFile(ctx, filename, config, collectFunc); err != nil {
+					if reportErr(filename, err) {
+						return
+					}
 					continue
 				}
 			}
@@ -734,19 +839,25 @@ func processWithStats(files []string, workers int, config extractor.Config, perF
 	if len(files) == 1 || workers == 1 {
 		for _, filename := range files {
 			if config.Recursive {
-				if err := extractFile(filename, config, collectFunc); err != nil {
-					fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
+				if err := extractFile(ctx, filename, config, collectFunc); err != nil {
+					if reportErr(filename, err) {
+						break
+					}
 					continue
 				}
 			} else if config.ScanDataOnly {
-				if err := processFileWithStatsAndBinaryParsing(filename, config, aggregated); err != nil {
-					fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
+				if err := processFileWithStatsAndBinaryParsing(ctx, filename, config, aggregated); err != nil {
+					if reportErr(filename, err) {
+						break
+					}
 					continue
 				}
 			} else {
 				// Use ExtractStringsFromFile with automatic mmap optimization
-				if err := extractor.ExtractStringsFromFile(filename, config, collectFunc); err != nil {
-					fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
+				if err := extractor.ExtractStringsFromFile(ctx, filename, config, collectFunc); err != nil {
+					if reportErr(filename, err) {
+						break
+					}
 					continue
 				}
 			}
@@ -760,7 +871,18 @@ func processWithStats(files []string, workers int, config extractor.Config, perF
 		// Start workers
 		for range workers {
 			wg.Go(func() {
-				for j := range jobs {
+				for {
+					var j job
+					var ok bool
+					select {
+					case <-ctx.Done():
+						return
+					case j, ok = <-jobs:
+						if !ok {
+							return
+						}
+					}
+
 					s := stats.New(config.MinLength)
 
 					// Create wrapper function for filter tracking if needed
@@ -769,35 +891,40 @@ func processWithStats(files []string, workers int, config extractor.Config, perF
 						localCollectFunc = makeFilterTrackingFunc(s, config)
 					}
 
+					res := s
 					if config.Recursive {
-						if err := extractFile(j.filename, config, localCollectFunc); err != nil {
-							fmt.Fprintf(os.Stderr, "strings: %s: %v\n", j.filename, err)
-							results <- nil
-							continue
+						if err := extractFile(ctx, j.filename, config, localCollectFunc); err != nil {
+							reportErr(j.filename, err)
+							res = nil
 						}
 					} else if config.ScanDataOnly {
-						if err := processFileWithStatsAndBinaryParsing(j.filename, config, s); err != nil {
-							fmt.Fprintf(os.Stderr, "strings: %s: %v\n", j.filename, err)
-							results <- nil
-							continue
+						if err := processFileWithStatsAndBinaryParsing(ctx, j.filename, config, s); err != nil {
+							reportErr(j.filename, err)
+							res = nil
 						}
 					} else {
 						// Use ExtractStringsFromFile with automatic mmap optimization
-						if err := extractor.ExtractStringsFromFile(j.filename, config, localCollectFunc); err != nil {
-							fmt.Fprintf(os.Stderr, "strings: %s: %v\n", j.filename, err)
-							results <- nil
-							continue
+						if err := extractor.ExtractStringsFromFile(ctx, j.filename, config, localCollectFunc); err != nil {
+							reportErr(j.filename, err)
+							res = nil
 						}
 					}
 
-					results <- s
+					select {
+					case results <- res:
+					case <-ctx.Done():
+						return
+					}
 				}
 			})
 		}
 
 		// Send jobs
 		for _, filename := range files {
-			jobs <- job{filename: filename}
+			select {
+			case jobs <- job{filename: filename}:
+			case <-ctx.Done():
+			}
 		}
 		close(jobs)
 
@@ -820,11 +947,13 @@ func processWithStats(files []string, workers int, config extractor.Config, perF
 }
 
 // processWithTriage processes files or stdin with security-triage output.
-func processWithTriage(files []string, workers int, config extractor.Config) {
+func processWithTriage(ctx context.Context, files []string, workers int, config extractor.Config) {
 	// stdin case
 	if len(files) == 0 {
 		tp := printer.NewTriagePrinter(config, os.Stdout)
-		extractor.ExtractStrings(os.Stdin, "", config, tp.PrintString)
+		if err := extractor.ExtractStrings(ctx, os.Stdin, "", config, tp.PrintString); err != nil {
+			reportErr("", err)
+		}
 		return
 	}
 
@@ -836,17 +965,35 @@ func processWithTriage(files []string, workers int, config extractor.Config) {
 		var wg sync.WaitGroup
 		for range workers {
 			wg.Go(func() {
-				for j := range jobs {
+				for {
+					var j job
+					var ok bool
+					select {
+					case <-ctx.Done():
+						return
+					case j, ok = <-jobs:
+						if !ok {
+							return
+						}
+					}
+
 					var buf bytes.Buffer
 					tp := printer.NewTriagePrinter(config, &buf)
-					err := extractFile(j.filename, config, tp.PrintString)
-					results <- result{index: j.index, output: buf.String(), err: err}
+					err := extractFile(ctx, j.filename, config, tp.PrintString)
+					select {
+					case results <- result{index: j.index, output: buf.String(), err: err}:
+					case <-ctx.Done():
+						return
+					}
 				}
 			})
 		}
 
 		for i, filename := range files {
-			jobs <- job{filename: filename, index: i}
+			select {
+			case jobs <- job{filename: filename, index: i}:
+			case <-ctx.Done():
+			}
 		}
 		close(jobs)
 
@@ -862,7 +1009,7 @@ func processWithTriage(files []string, workers int, config extractor.Config) {
 
 		for _, r := range outputs {
 			if r.err != nil {
-				fmt.Fprintf(os.Stderr, "strings: %s: %v\n", files[r.index], r.err)
+				reportErr(files[r.index], r.err)
 				continue
 			}
 			fmt.Print(r.output)
@@ -873,8 +1020,10 @@ func processWithTriage(files []string, workers int, config extractor.Config) {
 	// Sequential (single file or workers=1)
 	tp := printer.NewTriagePrinter(config, os.Stdout)
 	for _, filename := range files {
-		if err := extractFile(filename, config, tp.PrintString); err != nil {
-			fmt.Fprintf(os.Stderr, "strings: %s: %v\n", filename, err)
+		if err := extractFile(ctx, filename, config, tp.PrintString); err != nil {
+			if reportErr(filename, err) {
+				break
+			}
 			continue
 		}
 	}
@@ -883,7 +1032,7 @@ func processWithTriage(files []string, workers int, config extractor.Config) {
 // extractFileWithBinaryParsing detects the binary format, extracts strings from
 // its data sections (falling back to a full scan when parsing fails or no
 // sections are found), and routes each string through printFunc.
-func extractFileWithBinaryParsing(filename string, config extractor.Config, printFunc func([]byte, string, int64, extractor.Config)) error {
+func extractFileWithBinaryParsing(ctx context.Context, filename string, config extractor.Config, printFunc func([]byte, string, int64, extractor.Config)) error {
 	// Determine format
 	var format binary.Format
 	var err error
@@ -909,23 +1058,25 @@ func extractFileWithBinaryParsing(filename string, config extractor.Config, prin
 	sections, err := binary.ParseBinary(filename, format)
 	if err != nil {
 		// Fall back to regular scanning if parsing fails
-		return scanWholeFile(filename, config, printFunc)
+		return scanWholeFile(ctx, filename, config, printFunc)
 	}
 
 	// If no sections found (raw binary), scan the whole file
 	if len(sections) == 0 {
-		return scanWholeFile(filename, config, printFunc)
+		return scanWholeFile(ctx, filename, config, printFunc)
 	}
 
 	// Extract strings from each data section
 	for _, section := range sections {
-		extractor.ExtractFromSection(section.Data, section.Name, section.Offset, filename, config, printFunc)
+		if err := extractor.ExtractFromSection(ctx, section.Data, section.Name, section.Offset, filename, config, printFunc); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
 // scanWholeFile opens filename and extracts strings from its entire contents.
-func scanWholeFile(filename string, config extractor.Config, printFunc func([]byte, string, int64, extractor.Config)) error {
+func scanWholeFile(ctx context.Context, filename string, config extractor.Config, printFunc func([]byte, string, int64, extractor.Config)) error {
 	file, openErr := os.Open(filename)
 	if openErr != nil {
 		return openErr
@@ -936,8 +1087,7 @@ func scanWholeFile(filename string, config extractor.Config, printFunc func([]by
 		}
 	}()
 
-	extractor.ExtractStrings(file, filename, config, printFunc)
-	return nil
+	return extractor.ExtractStrings(ctx, file, filename, config, printFunc)
 }
 
 // makeFilterTrackingFunc creates a wrapper function that tracks both filtered and unfiltered counts
@@ -955,7 +1105,7 @@ func makeFilterTrackingFunc(s *stats.Statistics, _ extractor.Config) func([]byte
 }
 
 // processFileWithStatsAndBinaryParsing processes a file with binary parsing for statistics
-func processFileWithStatsAndBinaryParsing(filename string, config extractor.Config, s *stats.Statistics) error {
+func processFileWithStatsAndBinaryParsing(ctx context.Context, filename string, config extractor.Config, s *stats.Statistics) error {
 	// Determine format
 	var format binary.Format
 	var err error
@@ -1000,8 +1150,7 @@ func processFileWithStatsAndBinaryParsing(filename string, config extractor.Conf
 			collectFunc = makeFilterTrackingFunc(s, config)
 		}
 
-		extractor.ExtractStrings(file, filename, config, collectFunc)
-		return nil
+		return extractor.ExtractStrings(ctx, file, filename, config, collectFunc)
 	}
 
 	// Collect section names
@@ -1030,8 +1179,7 @@ func processFileWithStatsAndBinaryParsing(filename string, config extractor.Conf
 			collectFunc = makeFilterTrackingFunc(s, config)
 		}
 
-		extractor.ExtractStrings(file, filename, config, collectFunc)
-		return nil
+		return extractor.ExtractStrings(ctx, file, filename, config, collectFunc)
 	}
 
 	// Create wrapper function for filter tracking if needed
@@ -1042,7 +1190,9 @@ func processFileWithStatsAndBinaryParsing(filename string, config extractor.Conf
 
 	// Extract strings from data sections
 	for _, section := range sections {
-		extractor.ExtractFromSection(section.Data, section.Name, section.Offset, filename, config, collectFunc)
+		if err := extractor.ExtractFromSection(ctx, section.Data, section.Name, section.Offset, filename, config, collectFunc); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cmd/txtr/parallel_benchmark_test.go
+++ b/cmd/txtr/parallel_benchmark_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -88,7 +89,7 @@ func benchmarkSequential(b *testing.B, files []string) {
 
 	for i := 0; i < b.N; i++ {
 		for _, filename := range files {
-			_ = extractor.ExtractStringsFromFile(filename, config, printFunc)
+			_ = extractor.ExtractStringsFromFile(context.Background(), filename, config, printFunc)
 		}
 	}
 
@@ -139,7 +140,7 @@ func benchmarkParallel(b *testing.B, files []string, workers int) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		processFilesParallel(files, workers, config)
+		processFilesParallel(context.Background(), files, workers, config)
 	}
 
 	throughput := float64(totalSize) * float64(b.N) / b.Elapsed().Seconds() / 1e6
@@ -160,7 +161,7 @@ func BenchmarkSpeedup_4Files(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			for _, filename := range files {
-				_ = extractor.ExtractStringsFromFile(filename, config, printFunc)
+				_ = extractor.ExtractStringsFromFile(context.Background(), filename, config, printFunc)
 			}
 		}
 	})
@@ -168,14 +169,14 @@ func BenchmarkSpeedup_4Files(b *testing.B) {
 	b.Run("Parallel-2cores", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			processFilesParallel(files, 2, config)
+			processFilesParallel(context.Background(), files, 2, config)
 		}
 	})
 
 	b.Run("Parallel-4cores", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			processFilesParallel(files, 4, config)
+			processFilesParallel(context.Background(), files, 4, config)
 		}
 	})
 }
@@ -192,7 +193,7 @@ func BenchmarkSpeedup_8Files(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			for _, filename := range files {
-				_ = extractor.ExtractStringsFromFile(filename, config, printFunc)
+				_ = extractor.ExtractStringsFromFile(context.Background(), filename, config, printFunc)
 			}
 		}
 	})
@@ -200,21 +201,21 @@ func BenchmarkSpeedup_8Files(b *testing.B) {
 	b.Run("Parallel-2cores", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			processFilesParallel(files, 2, config)
+			processFilesParallel(context.Background(), files, 2, config)
 		}
 	})
 
 	b.Run("Parallel-4cores", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			processFilesParallel(files, 4, config)
+			processFilesParallel(context.Background(), files, 4, config)
 		}
 	})
 
 	b.Run("Parallel-8cores", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			processFilesParallel(files, 8, config)
+			processFilesParallel(context.Background(), files, 8, config)
 		}
 	})
 }
@@ -236,7 +237,7 @@ func BenchmarkProcessing_AutoWorkers(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		processFilesParallel(files, workers, config)
+		processFilesParallel(context.Background(), files, workers, config)
 	}
 
 	throughput := float64(totalSize) * float64(b.N) / b.Elapsed().Seconds() / 1e6
@@ -278,7 +279,7 @@ func BenchmarkParallelOverhead(b *testing.B) {
 		b.Run(formatWorkers(workers), func(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				processFilesParallel(files, workers, config)
+				processFilesParallel(context.Background(), files, workers, config)
 			}
 		})
 	}
@@ -311,7 +312,7 @@ func BenchmarkFileWorkerBalance(b *testing.B) {
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				processFilesParallel(files, tc.workers, config)
+				processFilesParallel(context.Background(), files, tc.workers, config)
 			}
 		})
 	}
@@ -330,7 +331,7 @@ func BenchmarkParallel_Allocations(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		processFilesParallel(files, 4, config)
+		processFilesParallel(context.Background(), files, 4, config)
 	}
 }
 

--- a/cmd/txtr/parallel_test.go
+++ b/cmd/txtr/parallel_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -54,7 +55,7 @@ func TestParallelProcessingOrder(t *testing.T) {
 	os.Stdout = w
 
 	// Run parallel processing
-	processFilesParallel(filePaths, 2, config)
+	processFilesParallel(context.Background(), filePaths, 2, config)
 
 	if err := w.Close(); err != nil {
 		t.Fatalf("Failed to close pipe writer: %v", err)
@@ -112,7 +113,7 @@ func TestParallelProcessingErrorHandling(t *testing.T) {
 	os.Stderr = w
 
 	// Run parallel processing
-	processFilesParallel([]string{file1, file2, file3}, 2, config)
+	processFilesParallel(context.Background(), []string{file1, file2, file3}, 2, config)
 
 	if err := w.Close(); err != nil {
 		t.Fatalf("Failed to close pipe writer: %v", err)
@@ -166,13 +167,15 @@ func TestSequentialVsParallel(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to open file %s: %v", filename, err)
 		}
-		extractor.ExtractStrings(file, filename, config, func(str []byte, fname string, _ int64, cfg extractor.Config) {
+		if err := extractor.ExtractStrings(context.Background(), file, filename, config, func(str []byte, fname string, _ int64, cfg extractor.Config) {
 			if cfg.PrintFileName && fname != "" {
 				seqBuf.WriteString(fname + ": ")
 			}
 			seqBuf.Write(str)
 			seqBuf.WriteString("\n")
-		})
+		}); err != nil {
+			t.Fatalf("ExtractStrings: %v", err)
+		}
 		if err := file.Close(); err != nil {
 			t.Fatalf("Failed to close file: %v", err)
 		}
@@ -187,7 +190,7 @@ func TestSequentialVsParallel(t *testing.T) {
 	}
 	os.Stdout = w
 
-	processFilesParallel(filePaths, 2, config)
+	processFilesParallel(context.Background(), filePaths, 2, config)
 
 	if err := w.Close(); err != nil {
 		t.Fatalf("Failed to close pipe writer: %v", err)
@@ -235,7 +238,7 @@ func TestJSONMultipleFiles(t *testing.T) {
 	}
 
 	// Process files with JSON output
-	jsonPrinter := processFilesParallelJSON(filePaths, 2, config)
+	jsonPrinter := processFilesParallelJSON(context.Background(), filePaths, 2, config)
 
 	// Verify we have 3 file results
 	if len(jsonPrinter.FileResults) != 3 {
@@ -284,7 +287,7 @@ func TestJSONWithErrors(t *testing.T) {
 	}
 
 	// Process files (including nonexistent one)
-	jsonPrinter := processFilesParallelJSON([]string{file1, file2, file3}, 2, config)
+	jsonPrinter := processFilesParallelJSON(context.Background(), []string{file1, file2, file3}, 2, config)
 
 	// Verify we have 3 file results
 	if len(jsonPrinter.FileResults) != 3 {
@@ -350,7 +353,9 @@ func TestJSONOutputStructure(t *testing.T) {
 		}
 	}()
 
-	extractor.ExtractStrings(file, testFile, config, tempPrinter.PrintString)
+	if err := extractor.ExtractStrings(context.Background(), file, testFile, config, tempPrinter.PrintString); err != nil {
+		t.Fatalf("ExtractStrings: %v", err)
+	}
 
 	if err := tempPrinter.Flush(); err != nil {
 		t.Fatalf("Failed to flush JSON: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,4 @@ require (
 
 require github.com/richardwooding/triage v0.1.0
 
-require github.com/richardwooding/archives v0.1.0
+require github.com/richardwooding/archives v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
-github.com/richardwooding/archives v0.1.0 h1:0zi9jrEMYw6jx9GcxwGIEHgbDzsYxa5EgXYonYxAuYE=
-github.com/richardwooding/archives v0.1.0/go.mod h1:j+3Xf8avzoJV6Qj+IGuvzvCWtOQGl+ixUW4a3mzK8bE=
+github.com/richardwooding/archives v0.2.0 h1:qEHu8GLM0OpTb1TWj3pCNriNDarFMuzqL/BTniR5LJ0=
+github.com/richardwooding/archives v0.2.0/go.mod h1:j+3Xf8avzoJV6Qj+IGuvzvCWtOQGl+ixUW4a3mzK8bE=
 github.com/richardwooding/triage v0.1.0 h1:EAnmEh/wlI0EJypyY73JM7SH/gg2vMne0HqHCQsbW1k=
 github.com/richardwooding/triage v0.1.0/go.mod h1:nbnguCFTQ9NOAS0iFBytSInQITjfKwx8LPd3XOPqBOk=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=

--- a/internal/extractor/benchmark_test.go
+++ b/internal/extractor/benchmark_test.go
@@ -2,6 +2,7 @@ package extractor
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"testing"
 )
@@ -173,7 +174,7 @@ func benchmarkExtractASCII(b *testing.B, size int) {
 
 	for i := 0; i < b.N; i++ {
 		reader := bytes.NewReader(data)
-		extractASCII(reader, "", config, printFunc, false)
+		_ = extractASCII(context.Background(), reader, "", config, printFunc, false)
 	}
 
 	// Calculate and report throughput
@@ -208,7 +209,7 @@ func benchmarkExtract8BitASCII(b *testing.B, size int) {
 
 	for i := 0; i < b.N; i++ {
 		reader := bytes.NewReader(data)
-		extractASCII(reader, "", config, printFunc, false)
+		_ = extractASCII(context.Background(), reader, "", config, printFunc, false)
 	}
 
 	throughput := float64(size) * float64(b.N) / b.Elapsed().Seconds() / 1e6
@@ -247,7 +248,7 @@ func benchmarkExtractUTF8(b *testing.B, size int) {
 
 			for i := 0; i < b.N; i++ {
 				reader := bytes.NewReader(data)
-				extractUTF8Aware(reader, "", config, printFunc)
+				_ = extractUTF8Aware(context.Background(), reader, "", config, printFunc)
 			}
 
 			throughput := float64(size) * float64(b.N) / b.Elapsed().Seconds() / 1e6
@@ -301,7 +302,7 @@ func benchmarkExtractUTF16(b *testing.B, size int, littleEndian bool) {
 
 	for i := 0; i < b.N; i++ {
 		reader := bytes.NewReader(data)
-		extractUTF16(reader, "", config, printFunc, byteOrder)
+		_ = extractUTF16(context.Background(), reader, "", config, printFunc, byteOrder)
 	}
 
 	throughput := float64(size) * float64(b.N) / b.Elapsed().Seconds() / 1e6
@@ -353,7 +354,7 @@ func benchmarkExtractUTF32(b *testing.B, size int, littleEndian bool) {
 
 	for i := 0; i < b.N; i++ {
 		reader := bytes.NewReader(data)
-		extractUTF32(reader, "", config, printFunc, byteOrder)
+		_ = extractUTF32(context.Background(), reader, "", config, printFunc, byteOrder)
 	}
 
 	throughput := float64(size) * float64(b.N) / b.Elapsed().Seconds() / 1e6
@@ -402,7 +403,7 @@ func benchmarkWithData(b *testing.B, data []byte) {
 
 	for i := 0; i < b.N; i++ {
 		reader := bytes.NewReader(data)
-		extractASCII(reader, "", config, printFunc, false)
+		_ = extractASCII(context.Background(), reader, "", config, printFunc, false)
 	}
 
 	throughput := float64(len(data)) * float64(b.N) / b.Elapsed().Seconds() / 1e6
@@ -440,7 +441,7 @@ func benchmarkExtractASCIIWithMinLength(b *testing.B, minLength int) {
 
 	for i := 0; i < b.N; i++ {
 		reader := bytes.NewReader(data)
-		extractASCII(reader, "", config, printFunc, false)
+		_ = extractASCII(context.Background(), reader, "", config, printFunc, false)
 	}
 
 	throughput := float64(len(data)) * float64(b.N) / b.Elapsed().Seconds() / 1e6
@@ -460,7 +461,7 @@ func BenchmarkEncodingComparison_10MB(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			reader := bytes.NewReader(data)
-			extractASCII(reader, "", config, printFunc, false)
+			_ = extractASCII(context.Background(), reader, "", config, printFunc, false)
 		}
 		throughput := float64(size) * float64(b.N) / b.Elapsed().Seconds() / 1e6
 		b.ReportMetric(throughput, "MB/s")
@@ -474,7 +475,7 @@ func BenchmarkEncodingComparison_10MB(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			reader := bytes.NewReader(data)
-			extractASCII(reader, "", config, printFunc, false)
+			_ = extractASCII(context.Background(), reader, "", config, printFunc, false)
 		}
 		throughput := float64(size) * float64(b.N) / b.Elapsed().Seconds() / 1e6
 		b.ReportMetric(throughput, "MB/s")
@@ -488,7 +489,7 @@ func BenchmarkEncodingComparison_10MB(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			reader := bytes.NewReader(data)
-			extractUTF8Aware(reader, "", config, printFunc)
+			_ = extractUTF8Aware(context.Background(), reader, "", config, printFunc)
 		}
 		throughput := float64(size) * float64(b.N) / b.Elapsed().Seconds() / 1e6
 		b.ReportMetric(throughput, "MB/s")
@@ -502,7 +503,7 @@ func BenchmarkEncodingComparison_10MB(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			reader := bytes.NewReader(data)
-			extractUTF16(reader, "", config, printFunc, binary.LittleEndian)
+			_ = extractUTF16(context.Background(), reader, "", config, printFunc, binary.LittleEndian)
 		}
 		throughput := float64(size) * float64(b.N) / b.Elapsed().Seconds() / 1e6
 		b.ReportMetric(throughput, "MB/s")
@@ -516,7 +517,7 @@ func BenchmarkEncodingComparison_10MB(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			reader := bytes.NewReader(data)
-			extractUTF32(reader, "", config, printFunc, binary.LittleEndian)
+			_ = extractUTF32(context.Background(), reader, "", config, printFunc, binary.LittleEndian)
 		}
 		throughput := float64(size) * float64(b.N) / b.Elapsed().Seconds() / 1e6
 		b.ReportMetric(throughput, "MB/s")

--- a/internal/extractor/cancel_test.go
+++ b/internal/extractor/cancel_test.go
@@ -1,0 +1,82 @@
+package extractor
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// makeScannable builds an input large enough that the extraction loops cross
+// several ctxChunk (64 KiB) cancellation-poll boundaries.
+func makeScannable() []byte {
+	var b bytes.Buffer
+	line := []byte("AAAAAAAAAAAAAAAA\x00") // printable run + delimiter
+	for b.Len() < 4*ctxChunk {
+		b.Write(line)
+	}
+	return b.Bytes()
+}
+
+func TestExtractStringsCancelledUpfront(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled before any work
+
+	cfg := Config{MinLength: 4, Encoding: "s"}
+	encodings := []string{"s", "S", "b", "l", "B", "L"}
+	for _, enc := range encodings {
+		cfg.Encoding = enc
+		called := false
+		err := ExtractStrings(ctx, bytes.NewReader(makeScannable()), "test", cfg, func([]byte, string, int64, Config) {
+			called = true
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("encoding %q: expected context.Canceled, got %v", enc, err)
+		}
+		if called {
+			t.Errorf("encoding %q: printFunc should not run when ctx is cancelled upfront", enc)
+		}
+	}
+}
+
+func TestExtractStringsCancelMidScan(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	cfg := Config{MinLength: 4, Encoding: "s"}
+	var count int
+	// Cancel after the first delivered string so the loop must observe it
+	// at the next 64 KiB poll boundary.
+	err := ExtractStrings(ctx, bytes.NewReader(makeScannable()), "test", cfg, func([]byte, string, int64, Config) {
+		count++
+		cancel()
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestExtractFromSectionCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cfg := Config{MinLength: 4, Encoding: "s"}
+	err := ExtractFromSection(ctx, makeScannable(), "sec", 0, "test", cfg, func([]byte, string, int64, Config) {})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestExtractStringsCompletesWithLiveContext(t *testing.T) {
+	cfg := Config{MinLength: 4, Encoding: "s"}
+	var got int
+	err := ExtractStrings(context.Background(), strings.NewReader("hello\x00world\x00"), "test", cfg, func([]byte, string, int64, Config) {
+		got++
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 2 {
+		t.Fatalf("expected 2 strings, got %d", got)
+	}
+}

--- a/internal/extractor/encoding_test.go
+++ b/internal/extractor/encoding_test.go
@@ -4,6 +4,7 @@ package extractor
 
 import (
 	"bytes"
+	"context"
 	"strings"
 	"testing"
 )
@@ -60,7 +61,9 @@ func TestExtractUTF8(t *testing.T) {
 			}
 
 			reader := strings.NewReader(tt.input)
-			ExtractStrings(reader, "", config, printFunc)
+			if err := ExtractStrings(context.Background(), reader, "", config, printFunc); err != nil {
+				t.Fatalf("ExtractStrings: %v", err)
+			}
 
 			if string(result) != tt.expected {
 				t.Errorf("got %q, want %q", string(result), tt.expected)
@@ -91,7 +94,9 @@ func TestExtractUTF16LE(t *testing.T) {
 	}
 
 	reader := bytes.NewReader(input)
-	ExtractStrings(reader, "", config, printFunc)
+	if err := ExtractStrings(context.Background(), reader, "", config, printFunc); err != nil {
+		t.Fatalf("ExtractStrings: %v", err)
+	}
 
 	if string(result) != "hello" {
 		t.Errorf("UTF-16LE extraction failed: got %q, want %q", string(result), "hello")
@@ -119,7 +124,9 @@ func TestExtractUTF16BE(t *testing.T) {
 	}
 
 	reader := bytes.NewReader(input)
-	ExtractStrings(reader, "", config, printFunc)
+	if err := ExtractStrings(context.Background(), reader, "", config, printFunc); err != nil {
+		t.Fatalf("ExtractStrings: %v", err)
+	}
 
 	if string(result) != "hello" {
 		t.Errorf("UTF-16BE extraction failed: got %q, want %q", string(result), "hello")
@@ -146,7 +153,9 @@ func TestExtractUTF32LE(t *testing.T) {
 	}
 
 	reader := bytes.NewReader(input)
-	ExtractStrings(reader, "", config, printFunc)
+	if err := ExtractStrings(context.Background(), reader, "", config, printFunc); err != nil {
+		t.Fatalf("ExtractStrings: %v", err)
+	}
 
 	if string(result) != "test" {
 		t.Errorf("UTF-32LE extraction failed: got %q, want %q", string(result), "test")
@@ -173,7 +182,9 @@ func TestExtractUTF32BE(t *testing.T) {
 	}
 
 	reader := bytes.NewReader(input)
-	ExtractStrings(reader, "", config, printFunc)
+	if err := ExtractStrings(context.Background(), reader, "", config, printFunc); err != nil {
+		t.Fatalf("ExtractStrings: %v", err)
+	}
 
 	if string(result) != "test" {
 		t.Errorf("UTF-32BE extraction failed: got %q, want %q", string(result), "test")
@@ -213,7 +224,9 @@ func TestIncludeAllWhitespace(t *testing.T) {
 			}
 
 			reader := strings.NewReader(input)
-			ExtractStrings(reader, "", config, printFunc)
+			if err := ExtractStrings(context.Background(), reader, "", config, printFunc); err != nil {
+				t.Fatalf("ExtractStrings: %v", err)
+			}
 
 			resultStr := string(result)
 			if !strings.Contains(resultStr, "hello") || !strings.Contains(resultStr, "world") {
@@ -260,7 +273,9 @@ func Test8BitASCII(t *testing.T) {
 			}
 
 			reader := bytes.NewReader(input)
-			ExtractStrings(reader, "", config, printFunc)
+			if err := ExtractStrings(context.Background(), reader, "", config, printFunc); err != nil {
+				t.Fatalf("ExtractStrings: %v", err)
+			}
 
 			if len(result) < tt.minChars {
 				t.Errorf("%s: expected at least %d chars, got %d", tt.name, tt.minChars, len(result))

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -4,14 +4,39 @@ package extractor
 
 import (
 	"bufio"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"unicode/utf16"
 	"unicode/utf8"
 )
+
+// printFunc is the callback that receives each extracted string:
+// (string bytes, source path, byte offset within the source, config).
+type printFunc = func([]byte, string, int64, Config)
+
+// ctxChunk bounds how much in-memory data the byte-slice extractors scan
+// between cancellation polls (64 KiB). The poll lives in an outer loop so the
+// hot inner loop carries no per-byte branch and keeps full throughput.
+const ctxChunk = 64 << 10
+
+// ctxReader makes a streaming read cancellable without any per-byte cost: it
+// checks ctx once per underlying Read, which (through bufio) happens once per
+// buffer refill rather than per byte. A cancelled context surfaces as a read
+// error that the extraction loops return (wrapping context.Canceled).
+type ctxReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (c ctxReader) Read(p []byte) (int, error) {
+	if err := c.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return c.r.Read(p)
+}
 
 // ColorMode specifies when to use colored output.
 type ColorMode int
@@ -51,35 +76,35 @@ type Config struct {
 	RecurseMaxBytes      int64            // Max total decompressed bytes (0 = default, <0 = unlimited)
 }
 
-// ExtractStrings reads from reader and extracts printable strings
-func ExtractStrings(reader io.Reader, filename string, config Config, printFunc func([]byte, string, int64, Config)) {
+// ExtractStrings reads from reader and extracts printable strings. It returns
+// ctx.Err() if the context is cancelled mid-scan, or a read error otherwise.
+func ExtractStrings(ctx context.Context, reader io.Reader, filename string, config Config, printFunc printFunc) error {
 	switch config.Encoding {
 	case "s": // 7-bit ASCII
-		extractASCII(reader, filename, config, printFunc, false)
+		return extractASCII(ctx, reader, filename, config, printFunc, false)
 	case "S": // 8-bit ASCII
-		extractASCII(reader, filename, config, printFunc, true)
+		return extractASCII(ctx, reader, filename, config, printFunc, true)
 	case "b": // 16-bit big-endian (UTF-16BE)
-		extractUTF16(reader, filename, config, printFunc, binary.BigEndian)
+		return extractUTF16(ctx, reader, filename, config, printFunc, binary.BigEndian)
 	case "l": // 16-bit little-endian (UTF-16LE)
-		extractUTF16(reader, filename, config, printFunc, binary.LittleEndian)
+		return extractUTF16(ctx, reader, filename, config, printFunc, binary.LittleEndian)
 	case "B": // 32-bit big-endian (UTF-32BE)
-		extractUTF32(reader, filename, config, printFunc, binary.BigEndian)
+		return extractUTF32(ctx, reader, filename, config, printFunc, binary.BigEndian)
 	case "L": // 32-bit little-endian (UTF-32LE)
-		extractUTF32(reader, filename, config, printFunc, binary.LittleEndian)
+		return extractUTF32(ctx, reader, filename, config, printFunc, binary.LittleEndian)
 	default:
-		extractASCII(reader, filename, config, printFunc, false)
+		return extractASCII(ctx, reader, filename, config, printFunc, false)
 	}
 }
 
 // extractASCII extracts 7-bit or 8-bit ASCII strings
-func extractASCII(reader io.Reader, filename string, config Config, printFunc func([]byte, string, int64, Config), allow8bit bool) {
+func extractASCII(ctx context.Context, reader io.Reader, filename string, config Config, printFunc printFunc, allow8bit bool) error {
 	// If Unicode mode is not default/invalid, use UTF-8 aware extraction
 	if config.Unicode != "default" && config.Unicode != "invalid" && config.Unicode != "" {
-		extractUTF8Aware(reader, filename, config, printFunc)
-		return
+		return extractUTF8Aware(ctx, reader, filename, config, printFunc)
 	}
 
-	bufReader := bufio.NewReader(reader)
+	bufReader := bufio.NewReader(ctxReader{ctx, reader})
 	var currentString []byte
 	var offset int64
 	var stringStartOffset int64
@@ -92,10 +117,9 @@ func extractASCII(reader io.Reader, filename string, config Config, printFunc fu
 				if len(currentString) >= config.MinLength && ShouldPrintString(currentString, config) {
 					printFunc(currentString, filename, stringStartOffset, config)
 				}
-				break
+				return nil
 			}
-			fmt.Fprintf(os.Stderr, "strings: error reading: %v\n", err)
-			return
+			return fmt.Errorf("error reading: %w", err)
 		}
 
 		if isPrintableASCII(b, allow8bit, config.IncludeAllWhitespace) {
@@ -116,8 +140,8 @@ func extractASCII(reader io.Reader, filename string, config Config, printFunc fu
 }
 
 // extractUTF8Aware extracts strings with UTF-8 awareness and special display modes
-func extractUTF8Aware(reader io.Reader, filename string, config Config, printFunc func([]byte, string, int64, Config)) {
-	bufReader := bufio.NewReader(reader)
+func extractUTF8Aware(ctx context.Context, reader io.Reader, filename string, config Config, printFunc printFunc) error {
+	bufReader := bufio.NewReader(ctxReader{ctx, reader})
 	var currentString []byte
 	var currentOutput []byte // May differ from currentString based on Unicode mode
 	var offset int64
@@ -131,10 +155,9 @@ func extractUTF8Aware(reader io.Reader, filename string, config Config, printFun
 				if len(currentString) >= config.MinLength && ShouldPrintString(currentOutput, config) {
 					printFunc(currentOutput, filename, stringStartOffset, config)
 				}
-				break
+				return nil
 			}
-			fmt.Fprintf(os.Stderr, "strings: error reading: %v\n", err)
-			return
+			return fmt.Errorf("error reading: %w", err)
 		}
 
 		// Check if this starts a UTF-8 sequence
@@ -227,8 +250,8 @@ func extractUTF8Aware(reader io.Reader, filename string, config Config, printFun
 }
 
 // extractUTF16 extracts UTF-16 encoded strings
-func extractUTF16(reader io.Reader, filename string, config Config, printFunc func([]byte, string, int64, Config), byteOrder binary.ByteOrder) {
-	bufReader := bufio.NewReader(reader)
+func extractUTF16(ctx context.Context, reader io.Reader, filename string, config Config, printFunc printFunc, byteOrder binary.ByteOrder) error {
+	bufReader := bufio.NewReader(ctxReader{ctx, reader})
 	var currentRunes []rune
 	var offset int64
 	var stringStartOffset int64
@@ -243,10 +266,9 @@ func extractUTF16(reader io.Reader, filename string, config Config, printFunc fu
 				if len(currentRunes) >= config.MinLength && ShouldPrintString(str, config) {
 					printFunc(str, filename, stringStartOffset, config)
 				}
-				break
+				return nil
 			}
-			fmt.Fprintf(os.Stderr, "strings: error reading: %v\n", err)
-			return
+			return fmt.Errorf("error reading: %w", err)
 		}
 
 		if n == 2 {
@@ -283,8 +305,8 @@ func extractUTF16(reader io.Reader, filename string, config Config, printFunc fu
 }
 
 // extractUTF32 extracts UTF-32 encoded strings
-func extractUTF32(reader io.Reader, filename string, config Config, printFunc func([]byte, string, int64, Config), byteOrder binary.ByteOrder) {
-	bufReader := bufio.NewReader(reader)
+func extractUTF32(ctx context.Context, reader io.Reader, filename string, config Config, printFunc printFunc, byteOrder binary.ByteOrder) error {
+	bufReader := bufio.NewReader(ctxReader{ctx, reader})
 	var currentRunes []rune
 	var offset int64
 	var stringStartOffset int64
@@ -299,10 +321,9 @@ func extractUTF32(reader io.Reader, filename string, config Config, printFunc fu
 				if len(currentRunes) >= config.MinLength && ShouldPrintString(str, config) {
 					printFunc(str, filename, stringStartOffset, config)
 				}
-				break
+				return nil
 			}
-			fmt.Fprintf(os.Stderr, "strings: error reading: %v\n", err)
-			return
+			return fmt.Errorf("error reading: %w", err)
 		}
 
 		if n == 4 {
@@ -380,42 +401,50 @@ func isPrintableRune(r rune, includeAllWhitespace bool) bool {
 }
 
 // ExtractFromSection extracts strings from a specific section's data
-func ExtractFromSection(data []byte, _ string, sectionOffset int64, filename string, config Config, printFunc func([]byte, string, int64, Config)) {
+func ExtractFromSection(ctx context.Context, data []byte, _ string, sectionOffset int64, filename string, config Config, printFunc printFunc) error {
 	// Use appropriate extraction based on encoding
 	switch config.Encoding {
 	case "s": // 7-bit ASCII
-		extractASCIIFromBytes(data, sectionOffset, filename, config, printFunc, false)
+		return extractASCIIFromBytes(ctx, data, sectionOffset, filename, config, printFunc, false)
 	case "S": // 8-bit ASCII
-		extractASCIIFromBytes(data, sectionOffset, filename, config, printFunc, true)
+		return extractASCIIFromBytes(ctx, data, sectionOffset, filename, config, printFunc, true)
 	case "b": // UTF-16BE
-		extractUTF16FromBytes(data, sectionOffset, filename, config, printFunc, binary.BigEndian)
+		return extractUTF16FromBytes(ctx, data, sectionOffset, filename, config, printFunc, binary.BigEndian)
 	case "l": // UTF-16LE
-		extractUTF16FromBytes(data, sectionOffset, filename, config, printFunc, binary.LittleEndian)
+		return extractUTF16FromBytes(ctx, data, sectionOffset, filename, config, printFunc, binary.LittleEndian)
 	case "B": // UTF-32BE
-		extractUTF32FromBytes(data, sectionOffset, filename, config, printFunc, binary.BigEndian)
+		return extractUTF32FromBytes(ctx, data, sectionOffset, filename, config, printFunc, binary.BigEndian)
 	case "L": // UTF-32LE
-		extractUTF32FromBytes(data, sectionOffset, filename, config, printFunc, binary.LittleEndian)
+		return extractUTF32FromBytes(ctx, data, sectionOffset, filename, config, printFunc, binary.LittleEndian)
 	default:
-		extractASCIIFromBytes(data, sectionOffset, filename, config, printFunc, false)
+		return extractASCIIFromBytes(ctx, data, sectionOffset, filename, config, printFunc, false)
 	}
 }
 
 // extractASCIIFromBytes is a helper for extracting from byte slices
-func extractASCIIFromBytes(data []byte, baseOffset int64, filename string, config Config, printFunc func([]byte, string, int64, Config), allow8bit bool) {
+func extractASCIIFromBytes(ctx context.Context, data []byte, baseOffset int64, filename string, config Config, printFunc printFunc, allow8bit bool) error {
 	var currentString []byte
 	var stringStartOffset int64
 
-	for i, b := range data {
-		if isPrintableASCII(b, allow8bit, config.IncludeAllWhitespace) {
-			if len(currentString) == 0 {
-				stringStartOffset = baseOffset + int64(i)
+	// Outer loop polls ctx every ctxChunk bytes; inner loop is branch-free.
+	for off := 0; off < len(data); off += ctxChunk {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		end := min(off+ctxChunk, len(data))
+		for i := off; i < end; i++ {
+			b := data[i]
+			if isPrintableASCII(b, allow8bit, config.IncludeAllWhitespace) {
+				if len(currentString) == 0 {
+					stringStartOffset = baseOffset + int64(i)
+				}
+				currentString = append(currentString, b)
+			} else {
+				if len(currentString) >= config.MinLength && ShouldPrintString(currentString, config) {
+					printFunc(currentString, filename, stringStartOffset, config)
+				}
+				currentString = currentString[:0]
 			}
-			currentString = append(currentString, b)
-		} else {
-			if len(currentString) >= config.MinLength && ShouldPrintString(currentString, config) {
-				printFunc(currentString, filename, stringStartOffset, config)
-			}
-			currentString = currentString[:0]
 		}
 	}
 
@@ -423,28 +452,37 @@ func extractASCIIFromBytes(data []byte, baseOffset int64, filename string, confi
 	if len(currentString) >= config.MinLength && ShouldPrintString(currentString, config) {
 		printFunc(currentString, filename, stringStartOffset, config)
 	}
+	return nil
 }
 
 // extractUTF16FromBytes extracts UTF-16 from byte slice
-func extractUTF16FromBytes(data []byte, baseOffset int64, filename string, config Config, printFunc func([]byte, string, int64, Config), byteOrder binary.ByteOrder) {
+func extractUTF16FromBytes(ctx context.Context, data []byte, baseOffset int64, filename string, config Config, printFunc printFunc, byteOrder binary.ByteOrder) error {
 	var currentRunes []rune
 	var stringStartOffset int64
 
-	for i := 0; i < len(data)-1; i += 2 {
-		u16 := byteOrder.Uint16(data[i : i+2])
-		r := rune(u16)
+	// Outer loop polls ctx every ctxChunk bytes (chunk is even, so 2-byte units
+	// never straddle a boundary); inner loop is branch-free.
+	for off := 0; off < len(data)-1; off += ctxChunk {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		end := min(off+ctxChunk, len(data)-1)
+		for i := off; i < end; i += 2 {
+			u16 := byteOrder.Uint16(data[i : i+2])
+			r := rune(u16)
 
-		if isPrintableRune(r, config.IncludeAllWhitespace) {
-			if len(currentRunes) == 0 {
-				stringStartOffset = baseOffset + int64(i)
+			if isPrintableRune(r, config.IncludeAllWhitespace) {
+				if len(currentRunes) == 0 {
+					stringStartOffset = baseOffset + int64(i)
+				}
+				currentRunes = append(currentRunes, r)
+			} else {
+				str := []byte(string(currentRunes))
+				if len(currentRunes) >= config.MinLength && ShouldPrintString(str, config) {
+					printFunc(str, filename, stringStartOffset, config)
+				}
+				currentRunes = currentRunes[:0]
 			}
-			currentRunes = append(currentRunes, r)
-		} else {
-			str := []byte(string(currentRunes))
-			if len(currentRunes) >= config.MinLength && ShouldPrintString(str, config) {
-				printFunc(str, filename, stringStartOffset, config)
-			}
-			currentRunes = currentRunes[:0]
 		}
 	}
 
@@ -452,28 +490,37 @@ func extractUTF16FromBytes(data []byte, baseOffset int64, filename string, confi
 	if len(currentRunes) >= config.MinLength && ShouldPrintString(str, config) {
 		printFunc(str, filename, stringStartOffset, config)
 	}
+	return nil
 }
 
 // extractUTF32FromBytes extracts UTF-32 from byte slice
-func extractUTF32FromBytes(data []byte, baseOffset int64, filename string, config Config, printFunc func([]byte, string, int64, Config), byteOrder binary.ByteOrder) {
+func extractUTF32FromBytes(ctx context.Context, data []byte, baseOffset int64, filename string, config Config, printFunc printFunc, byteOrder binary.ByteOrder) error {
 	var currentRunes []rune
 	var stringStartOffset int64
 
-	for i := 0; i < len(data)-3; i += 4 {
-		u32 := byteOrder.Uint32(data[i : i+4])
-		r := rune(u32)
+	// Outer loop polls ctx every ctxChunk bytes (chunk is divisible by 4, so
+	// 4-byte units never straddle a boundary); inner loop is branch-free.
+	for off := 0; off < len(data)-3; off += ctxChunk {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		end := min(off+ctxChunk, len(data)-3)
+		for i := off; i < end; i += 4 {
+			u32 := byteOrder.Uint32(data[i : i+4])
+			r := rune(u32)
 
-		if isPrintableRune(r, config.IncludeAllWhitespace) && utf8.ValidRune(r) {
-			if len(currentRunes) == 0 {
-				stringStartOffset = baseOffset + int64(i)
+			if isPrintableRune(r, config.IncludeAllWhitespace) && utf8.ValidRune(r) {
+				if len(currentRunes) == 0 {
+					stringStartOffset = baseOffset + int64(i)
+				}
+				currentRunes = append(currentRunes, r)
+			} else {
+				str := []byte(string(currentRunes))
+				if len(currentRunes) >= config.MinLength && ShouldPrintString(str, config) {
+					printFunc(str, filename, stringStartOffset, config)
+				}
+				currentRunes = currentRunes[:0]
 			}
-			currentRunes = append(currentRunes, r)
-		} else {
-			str := []byte(string(currentRunes))
-			if len(currentRunes) >= config.MinLength && ShouldPrintString(str, config) {
-				printFunc(str, filename, stringStartOffset, config)
-			}
-			currentRunes = currentRunes[:0]
 		}
 	}
 
@@ -481,4 +528,5 @@ func extractUTF32FromBytes(data []byte, baseOffset int64, filename string, confi
 	if len(currentRunes) >= config.MinLength && ShouldPrintString(str, config) {
 		printFunc(str, filename, stringStartOffset, config)
 	}
+	return nil
 }

--- a/internal/extractor/extractor_test.go
+++ b/internal/extractor/extractor_test.go
@@ -2,6 +2,7 @@ package extractor
 
 import (
 	"bytes"
+	"context"
 	"testing"
 )
 
@@ -86,7 +87,9 @@ func TestExtractStrings(t *testing.T) {
 			}
 
 			bufReader := bytes.NewReader(tt.input)
-			ExtractStrings(bufReader, "", config, printFunc)
+			if err := ExtractStrings(context.Background(), bufReader, "", config, printFunc); err != nil {
+				t.Fatalf("ExtractStrings: %v", err)
+			}
 
 			if len(found) != len(tt.expected) {
 				t.Errorf("found %d strings, expected %d", len(found), len(tt.expected))

--- a/internal/extractor/filter_benchmark_test.go
+++ b/internal/extractor/filter_benchmark_test.go
@@ -2,6 +2,7 @@ package extractor
 
 import (
 	"bytes"
+	"context"
 	"regexp"
 	"testing"
 )
@@ -143,7 +144,7 @@ func BenchmarkExtractWithFilter_NoFilter(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		reader := bytes.NewReader(data)
-		extractASCII(reader, "", config, printFunc, false)
+		_ = extractASCII(context.Background(), reader, "", config, printFunc, false)
 	}
 
 	throughput := float64(len(data)) * float64(b.N) / b.Elapsed().Seconds() / 1e6
@@ -165,7 +166,7 @@ func BenchmarkExtractWithFilter_SimplePattern(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		reader := bytes.NewReader(data)
-		extractASCII(reader, "", config, printFunc, false)
+		_ = extractASCII(context.Background(), reader, "", config, printFunc, false)
 	}
 
 	throughput := float64(len(data)) * float64(b.N) / b.Elapsed().Seconds() / 1e6
@@ -189,7 +190,7 @@ func BenchmarkExtractWithFilter_ComplexPattern(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		reader := bytes.NewReader(data)
-		extractASCII(reader, "", config, printFunc, false)
+		_ = extractASCII(context.Background(), reader, "", config, printFunc, false)
 	}
 
 	throughput := float64(len(data)) * float64(b.N) / b.Elapsed().Seconds() / 1e6
@@ -215,7 +216,7 @@ func BenchmarkExtractWithFilter_MultiplePatterns(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		reader := bytes.NewReader(data)
-		extractASCII(reader, "", config, printFunc, false)
+		_ = extractASCII(context.Background(), reader, "", config, printFunc, false)
 	}
 
 	throughput := float64(len(data)) * float64(b.N) / b.Elapsed().Seconds() / 1e6

--- a/internal/extractor/fuzz_test.go
+++ b/internal/extractor/fuzz_test.go
@@ -2,6 +2,7 @@ package extractor
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"regexp"
 	"testing"
@@ -50,7 +51,7 @@ func FuzzExtractASCII(f *testing.F) {
 		}()
 
 		// Execute extraction
-		extractASCII(reader, "", config, printFunc, allow8bit)
+		_ = extractASCII(context.Background(), reader, "", config, printFunc, allow8bit)
 
 		// Invariant 1: All results meet minimum length
 		for i, result := range results {
@@ -77,7 +78,7 @@ func FuzzExtractASCII(f *testing.F) {
 			results2 = append(results2, append([]byte(nil), str...))
 		}
 		reader2 := bytes.NewReader(data)
-		extractASCII(reader2, "", config, printFunc2, allow8bit)
+		_ = extractASCII(context.Background(), reader2, "", config, printFunc2, allow8bit)
 
 		if len(results) != len(results2) {
 			t.Errorf("Non-deterministic: got %d strings, second run got %d",
@@ -136,7 +137,7 @@ func FuzzExtractUTF8Aware(f *testing.F) {
 				}
 				done <- true
 			}()
-			extractUTF8Aware(reader, "", config, printFunc)
+			_ = extractUTF8Aware(context.Background(), reader, "", config, printFunc)
 		}()
 
 		select {
@@ -216,7 +217,7 @@ func FuzzExtractUTF16(f *testing.F) {
 				}
 				done <- true
 			}()
-			extractUTF16(reader, "", config, printFunc, byteOrder)
+			_ = extractUTF16(context.Background(), reader, "", config, printFunc, byteOrder)
 		}()
 
 		select {
@@ -307,7 +308,7 @@ func FuzzExtractUTF32(f *testing.F) {
 				}
 				done <- true
 			}()
-			extractUTF32(reader, "", config, printFunc, byteOrder)
+			_ = extractUTF32(context.Background(), reader, "", config, printFunc, byteOrder)
 		}()
 
 		select {

--- a/internal/extractor/mmap.go
+++ b/internal/extractor/mmap.go
@@ -1,7 +1,9 @@
 package extractor
 
 import (
+	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -42,16 +44,17 @@ func shouldUseMmap(path string, config Config) bool {
 //
 // This function provides transparent optimization - it will use mmap when
 // beneficial and fall back to buffered I/O when appropriate.
-func ExtractStringsFromFile(path string, config Config, printFunc func([]byte, string, int64, Config)) error {
+func ExtractStringsFromFile(ctx context.Context, path string, config Config, printFunc printFunc) error {
 	// Decide whether to use mmap
 	if shouldUseMmap(path, config) {
 		// Try mmap first
-		err := extractStringsWithMmap(path, config, printFunc)
-		if err == nil {
-			return nil
+		err := extractStringsWithMmap(ctx, path, config, printFunc)
+		// Success or cancellation: return as-is. Only a genuine mmap failure
+		// (permissions, OS limits, etc.) should trigger the buffered fallback —
+		// a cancelled context must not be retried.
+		if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
 		}
-		// If mmap fails, fall back to buffered I/O
-		// This can happen due to permissions, OS limits, etc.
 		fmt.Fprintf(os.Stderr, "warning: mmap failed for %s: %v, falling back to buffered I/O\n", path, err)
 	}
 
@@ -67,14 +70,13 @@ func ExtractStringsFromFile(path string, config Config, printFunc func([]byte, s
 		}
 	}()
 
-	ExtractStrings(file, path, config, printFunc)
-	return nil
+	return ExtractStrings(ctx, file, path, config, printFunc)
 }
 
 // extractStringsWithMmap extracts strings using memory-mapped I/O.
 // It uses the golang.org/x/exp/mmap package to map the file into memory
 // and then delegates to the appropriate *FromBytes() function.
-func extractStringsWithMmap(path string, config Config, printFunc func([]byte, string, int64, Config)) error {
+func extractStringsWithMmap(ctx context.Context, path string, config Config, printFunc printFunc) error {
 	// Open the file with mmap
 	reader, err := mmap.Open(path)
 	if err != nil {
@@ -89,6 +91,11 @@ func extractStringsWithMmap(path string, config Config, printFunc func([]byte, s
 
 	// Get the file size from the mmap reader (avoids redundant syscall)
 	fileSize := int64(reader.Len())
+
+	// Bail out before the (uninterruptible) bulk read if already cancelled.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	// Read the entire file into memory
 	// Note: mmap.ReaderAt implements ReadAt, we need to read into a slice
@@ -106,41 +113,45 @@ func extractStringsWithMmap(path string, config Config, printFunc func([]byte, s
 		// 7-bit ASCII
 		if config.Unicode != "" && config.Unicode != "default" && config.Unicode != "invalid" {
 			// UTF-8 aware mode
-			extractUTF8AwareFromBytes(data, path, config, printFunc)
-		} else {
-			extractASCIIFromBytes(data, 0, path, config, printFunc, false)
+			return extractUTF8AwareFromBytes(ctx, data, path, config, printFunc)
 		}
+		return extractASCIIFromBytes(ctx, data, 0, path, config, printFunc, false)
 	case "S":
 		// 8-bit ASCII
-		extractASCIIFromBytes(data, 0, path, config, printFunc, true)
+		return extractASCIIFromBytes(ctx, data, 0, path, config, printFunc, true)
 	case "b":
 		// UTF-16 big-endian
-		extractUTF16FromBytes(data, 0, path, config, printFunc, binary.BigEndian)
+		return extractUTF16FromBytes(ctx, data, 0, path, config, printFunc, binary.BigEndian)
 	case "l":
 		// UTF-16 little-endian
-		extractUTF16FromBytes(data, 0, path, config, printFunc, binary.LittleEndian)
+		return extractUTF16FromBytes(ctx, data, 0, path, config, printFunc, binary.LittleEndian)
 	case "B":
 		// UTF-32 big-endian
-		extractUTF32FromBytes(data, 0, path, config, printFunc, binary.BigEndian)
+		return extractUTF32FromBytes(ctx, data, 0, path, config, printFunc, binary.BigEndian)
 	case "L":
 		// UTF-32 little-endian
-		extractUTF32FromBytes(data, 0, path, config, printFunc, binary.LittleEndian)
+		return extractUTF32FromBytes(ctx, data, 0, path, config, printFunc, binary.LittleEndian)
 	default:
 		return fmt.Errorf("unsupported encoding: %s", config.Encoding)
 	}
-
-	return nil
 }
 
 // extractUTF8AwareFromBytes is a helper that wraps the byte-slice extraction
 // for UTF-8 aware mode. This function didn't exist before, so we create it here.
-func extractUTF8AwareFromBytes(data []byte, filename string, config Config, printFunc func([]byte, string, int64, Config)) {
+func extractUTF8AwareFromBytes(ctx context.Context, data []byte, filename string, config Config, printFunc printFunc) error {
 	// For UTF-8 aware mode, we need to process byte-by-byte like the streaming version
 	// We can't use the simple ASCII extractor because we need UTF-8 validation
 	var currentString []byte
 	var startOffset int64
+	nextCheck := 0 // index at which to next poll ctx (variable-stride loop)
 
 	for i := 0; i < len(data); {
+		if i >= nextCheck {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			nextCheck = i + ctxChunk
+		}
 		b := data[i]
 
 		// Check if this is the start of a UTF-8 sequence
@@ -194,4 +205,5 @@ func extractUTF8AwareFromBytes(data []byte, filename string, config Config, prin
 			printFunc(currentString, filename, startOffset, config)
 		}
 	}
+	return nil
 }

--- a/internal/extractor/mmap_benchmark_test.go
+++ b/internal/extractor/mmap_benchmark_test.go
@@ -2,6 +2,7 @@ package extractor
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -44,7 +45,7 @@ func BenchmarkExtract_1MB_BufferedIO(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = ExtractStringsFromFile(testFile, config, printFunc)
+		_ = ExtractStringsFromFile(context.Background(), testFile, config, printFunc)
 	}
 }
 
@@ -61,7 +62,7 @@ func BenchmarkExtract_1MB_Mmap(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = ExtractStringsFromFile(testFile, config, printFunc)
+		_ = ExtractStringsFromFile(context.Background(), testFile, config, printFunc)
 	}
 }
 
@@ -79,7 +80,7 @@ func BenchmarkExtract_10MB_BufferedIO(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = ExtractStringsFromFile(testFile, config, printFunc)
+		_ = ExtractStringsFromFile(context.Background(), testFile, config, printFunc)
 	}
 }
 
@@ -96,7 +97,7 @@ func BenchmarkExtract_10MB_Mmap(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = ExtractStringsFromFile(testFile, config, printFunc)
+		_ = ExtractStringsFromFile(context.Background(), testFile, config, printFunc)
 	}
 }
 
@@ -114,7 +115,7 @@ func BenchmarkExtract_100MB_BufferedIO(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = ExtractStringsFromFile(testFile, config, printFunc)
+		_ = ExtractStringsFromFile(context.Background(), testFile, config, printFunc)
 	}
 }
 
@@ -131,7 +132,7 @@ func BenchmarkExtract_100MB_Mmap(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = ExtractStringsFromFile(testFile, config, printFunc)
+		_ = ExtractStringsFromFile(context.Background(), testFile, config, printFunc)
 	}
 }
 
@@ -164,7 +165,7 @@ func BenchmarkExtractUTF16_10MB_BufferedIO(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = ExtractStringsFromFile(testFile, config, printFunc)
+		_ = ExtractStringsFromFile(context.Background(), testFile, config, printFunc)
 	}
 }
 
@@ -196,7 +197,7 @@ func BenchmarkExtractUTF16_10MB_Mmap(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = ExtractStringsFromFile(testFile, config, printFunc)
+		_ = ExtractStringsFromFile(context.Background(), testFile, config, printFunc)
 	}
 }
 
@@ -227,7 +228,7 @@ func BenchmarkExtract8BitASCII_10MB_BufferedIO(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = ExtractStringsFromFile(testFile, config, printFunc)
+		_ = ExtractStringsFromFile(context.Background(), testFile, config, printFunc)
 	}
 }
 
@@ -257,6 +258,6 @@ func BenchmarkExtract8BitASCII_10MB_Mmap(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = ExtractStringsFromFile(testFile, config, printFunc)
+		_ = ExtractStringsFromFile(context.Background(), testFile, config, printFunc)
 	}
 }

--- a/internal/extractor/mmap_test.go
+++ b/internal/extractor/mmap_test.go
@@ -2,6 +2,7 @@ package extractor
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -147,7 +148,7 @@ func TestExtractStringsFromFile(t *testing.T) {
 				collectedStrings = append(collectedStrings, string(str))
 			}
 
-			err := ExtractStringsFromFile(testFile, tt.config, printFunc)
+			err := ExtractStringsFromFile(context.Background(), testFile, tt.config, printFunc)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ExtractStringsFromFile() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -202,7 +203,7 @@ func TestMmapEquivalence(t *testing.T) {
 				bufferedStrings = append(bufferedStrings, string(str))
 			}
 
-			if err := ExtractStringsFromFile(testFile, configBuffered, printFuncBuffered); err != nil {
+			if err := ExtractStringsFromFile(context.Background(), testFile, configBuffered, printFuncBuffered); err != nil {
 				t.Fatalf("Buffered extraction failed: %v", err)
 			}
 
@@ -216,7 +217,7 @@ func TestMmapEquivalence(t *testing.T) {
 				mmapStrings = append(mmapStrings, string(str))
 			}
 
-			if err := ExtractStringsFromFile(testFile, configMmap, printFuncMmap); err != nil {
+			if err := ExtractStringsFromFile(context.Background(), testFile, configMmap, printFuncMmap); err != nil {
 				t.Fatalf("Mmap extraction failed: %v", err)
 			}
 
@@ -260,7 +261,7 @@ func TestMmapFallback(t *testing.T) {
 	}
 
 	// This should succeed even if mmap fails, as it falls back to buffered I/O
-	if err := ExtractStringsFromFile(testFile, config, printFunc); err != nil {
+	if err := ExtractStringsFromFile(context.Background(), testFile, config, printFunc); err != nil {
 		t.Errorf("ExtractStringsFromFile() should fallback on mmap failure, but got error: %v", err)
 	}
 
@@ -292,7 +293,7 @@ func TestMmapWithUTF16(t *testing.T) {
 		extracted = append(extracted, string(str))
 	}
 
-	if err := ExtractStringsFromFile(testFile, config, printFunc); err != nil {
+	if err := ExtractStringsFromFile(context.Background(), testFile, config, printFunc); err != nil {
 		t.Fatalf("ExtractStringsFromFile() failed: %v", err)
 	}
 
@@ -330,7 +331,7 @@ func TestMmapWithUTF32(t *testing.T) {
 		extracted = append(extracted, string(str))
 	}
 
-	if err := ExtractStringsFromFile(testFile, config, printFunc); err != nil {
+	if err := ExtractStringsFromFile(context.Background(), testFile, config, printFunc); err != nil {
 		t.Fatalf("ExtractStringsFromFile() failed: %v", err)
 	}
 
@@ -350,7 +351,7 @@ func TestMmapNonexistentFile(t *testing.T) {
 
 	printFunc := func(_ []byte, _ string, _ int64, _ Config) {}
 
-	err := ExtractStringsFromFile("/nonexistent/file.bin", config, printFunc)
+	err := ExtractStringsFromFile(context.Background(), "/nonexistent/file.bin", config, printFunc)
 	if err == nil {
 		t.Error("Expected error for nonexistent file, got nil")
 	}


### PR DESCRIPTION
## Summary

Upgrades `github.com/richardwooding/archives` **v0.1.0 → v0.2.0**, whose `Walk` now takes a `context.Context` and is cancellable both between members and mid-stream. Threads a cancellable context end-to-end so a long scan, worker pool, or archive walk aborts promptly.

- `main()` derives ctx from `signal.NotifyContext` (SIGINT/SIGTERM), threads it through every output mode, and exits **130** with a single `strings: interrupted` on cancel (JSON still flushes partial output first).
- `extractor.ExtractStrings` / `ExtractFromSection` / `ExtractStringsFromFile` and the internal loops take `ctx` and return `error` (`ctx.Err()` on cancel).
- Worker pools (text/JSON/stats/triage) select on `ctx.Done()` to stop pulling jobs and to avoid blocking on result sends; `reportErr` suppresses repeated cancellation noise.

## Performance

A naive per-byte `ctx.Err()` check regressed ASCII throughput **~8%** (benchstat vs base). Replaced with:
- **Streaming loops** → `ctxReader` wrapper polling ctx once per buffer refill (no per-byte cost).
- **Byte-slice/mmap loops** → poll once per 64 KiB (`ctxChunk`) with a branch-free inner loop.

Net regression **~1.1%** (10 MB case statistically indistinguishable); mmap byte-slice path slightly faster.

## Verification

- `go build` / `go vet` / `golangci-lint` clean; full `go test ./...` passes.
- New `internal/extractor/cancel_test.go` (upfront, mid-scan, section, live-context).
- 20s `FuzzExtractASCII` smoke — no crashes.
- Manual: SIGINT during a 763 MB scan aborts instantly → `strings: interrupted`, exit 130. All output modes + archive recursion verified normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)