### PR TITLE
ci: bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: stable
           cache: true
@@ -27,7 +27,7 @@ jobs:
         run: set -o pipefail; go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         continue-on-error: true
         with:
@@ -39,10 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: stable
           cache: true
@@ -58,16 +58,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: stable
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.9.0
           args: --timeout=5m
@@ -77,12 +77,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: stable
           cache: true
@@ -91,21 +91,21 @@ jobs:
       # `check` error. Pinned to v2.15.4 (keeps it a warning, still emits the
       # cross-platform Homebrew formula) until the config migrates off `brews`.
       - name: Check GoReleaser config
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: 'v2.15.4'
           args: check
 
       - name: Test GoReleaser build
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: 'v2.15.4'
           args: build --snapshot --clean
 
       - name: Upload snapshot artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
           name: snapshot-artifacts
@@ -119,10 +119,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: stable
           cache: true
@@ -131,7 +131,7 @@ jobs:
         run: set -o pipefail; go test -bench=. -benchmem -benchtime=1s -timeout=10m ./... 2>&1 | tee benchmark.txt
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: benchmark-results
           path: benchmark.txt

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -36,16 +36,16 @@ jobs:
           - FuzzFilterPatterns
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: stable
           cache: true
 
       - name: Restore fuzz corpus cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/go-build/fuzz
           key: fuzz-corpus-extractor-${{ matrix.target }}-${{ github.sha }}
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload fuzz logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: fuzz-logs-extractor-${{ matrix.target }}
           path: fuzz-*.log
@@ -100,16 +100,16 @@ jobs:
           - FuzzDetectFormat
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: stable
           cache: true
 
       - name: Restore fuzz corpus cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/go-build/fuzz
           key: fuzz-corpus-binary-${{ matrix.target }}-${{ github.sha }}
@@ -135,7 +135,7 @@ jobs:
 
       - name: Upload fuzz logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: fuzz-logs-binary-${{ matrix.target }}
           path: fuzz-*.log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # CRITICAL: Required for GoReleaser to work properly
 
@@ -24,20 +24,20 @@ jobs:
         run: git fetch --force --tags
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: stable
           cache: true
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         # Required for multi-platform container builds
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -47,7 +47,7 @@ jobs:
       # config. v2.15.4 still emits the cross-platform Homebrew formula. Revisit
       # when migrating off `brews` (note: homebrew_casks is macOS-only).
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6.1.0
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: 'v2.15.4'
@@ -57,7 +57,7 @@ jobs:
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: release-artifacts


### PR DESCRIPTION
## Summary

Resolves the `Node.js 20 is deprecated ... being forced to run on Node.js 24` warnings seen in workflow runs. Every action is moved to the **lowest major version that natively targets the Node 24 runtime**, verified by inspecting each action's `runs.using` in `action.yml`.

| Action | From | To | Notes |
|---|---|---|---|
| actions/checkout | v4 | v5 | |
| actions/setup-go | v5 | v6 | |
| actions/upload-artifact | v4 | **v6** | v5 still targets node20 |
| actions/cache | v4 | v5 | |
| codecov/codecov-action | v4 | v5 | now a composite wrapper |
| golangci/golangci-lint-action | v7 | **v9** | v8 still targets node20; v9 keeps `version`/`args` inputs |
| goreleaser/goreleaser-action | v6 / v6.1.0 | v7 | |
| docker/setup-qemu-action | v3 | v4 | |
| docker/setup-buildx-action | v3 | v4 | |
| docker/login-action | v3 | v4 | |

Tool versions are untouched: golangci-lint **v2.9.0**, GoReleaser **v2.15.4** (still pinned to keep `brews` a warning, not a hard error).

## Notes
- `golangci-lint-action@v9` enables config-schema `verify` by default; `.golangci.yml` is already valid `version: '2'`, so the Lint job validates it.
- `release.yml`-only actions (docker/*, goreleaser) can't be exercised by PR CI (release runs on tags) — the `GoReleaser Check` job in `ci.yml` covers the goreleaser-action bump; the docker action bumps are version-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)