### PR TITLE
chore(dependabot): add grouped github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,12 @@ updates:
         update-types:
           - "minor"
           - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Add a grouped `github-actions` Dependabot ecosystem so action version bumps are managed and batched (minor/patch grouped into one PR; majors stay separate).

Applies the grouping technique from the SPAN Chronicle article "Taming Dependabot Fatigue".

🤖 Generated with [Claude Code](https://claude.com/claude-code)