### PR TITLE
docs: add gloam GitHub Pages site

### DIFF
--- a/.github/workflows/gloam-sync.yml
+++ b/.github/workflows/gloam-sync.yml
@@ -1,0 +1,52 @@
+# Scheduled gloam sync — opens a PR when the vendored gloam.css/gloam.js
+# drift from upstream (github.com/richardwooding/gloam@main).
+#
+# Copy this into a consumer's .github/workflows/ and set GLOAM_DIR to the
+# directory that holds gloam.css/gloam.js (e.g. "site" or "docs").
+name: gloam-sync
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  GLOAM_DIR: docs   # folder holding gloam.css/gloam.js
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Sync gloam assets
+        run: sh "$GLOAM_DIR/sync-gloam.sh" "$GLOAM_DIR"
+
+      - name: Open a PR if anything changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "gloam already up to date."
+            exit 0
+          fi
+          BRANCH="chore/gloam-sync"
+          COMMIT="$(sed -n 's/^commit=//p' "$GLOAM_DIR/.gloam-version")"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git switch -C "$BRANCH"
+          git add -A
+          git commit -m "chore(site): sync gloam assets to ${COMMIT}"
+          git push -f origin "$BRANCH"
+          STATE="$(gh pr view "$BRANCH" --json state --jq .state 2>/dev/null || true)"
+          if [ "$STATE" = "OPEN" ]; then
+            echo "PR already open; updated the branch."
+          else
+            gh pr create --base "${GITHUB_REF_NAME}" --head "$BRANCH" \
+              --title "chore(site): sync gloam design assets" \
+              --body "Automated sync of \`gloam.css\`/\`gloam.js\` from [richardwooding/gloam](https://github.com/richardwooding/gloam)@\`${COMMIT}\`. See \`$GLOAM_DIR/.gloam-version\`."
+          fi

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,34 @@
+name: pages
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+# Allow the Pages deployment; one concurrent deploy at a time.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/configure-pages@v6
+        with:
+          enablement: true # create/enable the Pages site if it isn't already
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: docs
+      - id: deployment
+        uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A clone of GNU strings utility written in Go 1.26.
 
 Extracts printable strings from binary files. Aims to be compatible with GNU strings.
 
+**Website:** [richardwooding.github.io/txtr](https://richardwooding.github.io/txtr/)
+
 ## Installation
 
 ### Homebrew (Recommended for macOS/Linux)

--- a/docs/.gloam-version
+++ b/docs/.gloam-version
@@ -1,0 +1,3 @@
+repo=richardwooding/gloam
+ref=main
+commit=4f8b9ff5e5d11743eaae00f79f6fcfeef74fb75c

--- a/docs/gloam.css
+++ b/docs/gloam.css
@@ -1,0 +1,204 @@
+/*!
+ * gloam.css — a dark-first, purple-accented, terminal-flavored design language.
+ * https://github.com/richardwooding/gloam · MIT
+ *
+ * Tokens are prefixed --gl-*, component classes gl-*, so it drops into any page
+ * without collisions. Dark is the default; light is served via
+ * prefers-color-scheme AND an explicit :root[data-theme="light"|"dark"] override.
+ */
+
+:root {
+  --gl-bg: #0d1117;
+  --gl-panel: #161b22;
+  --gl-panel-2: #1c2230;
+  --gl-border: #2a3038;
+  --gl-fg: #e6edf3;
+  --gl-muted: #9aa7b4;
+  --gl-faint: #6b7684;
+  --gl-accent: #a371f7;
+  --gl-accent-2: #bd93ff;
+  --gl-accent-ink: #f5efff;
+  --gl-green: #3fb950;
+  --gl-amber: #d29922;
+  --gl-radius: 14px;
+  --gl-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  --gl-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --gl-maxw: 1080px;
+}
+
+/* Light palette: auto (system) … */
+@media (prefers-color-scheme: light) {
+  :root {
+    --gl-bg: #ffffff;
+    --gl-panel: #f6f8fa;
+    --gl-panel-2: #eef1f5;
+    --gl-border: #d8dee4;
+    --gl-fg: #1f2328;
+    --gl-muted: #59636e;
+    --gl-faint: #818b98;
+    --gl-accent: #7c3aed;
+    --gl-accent-2: #6d28d9;
+    --gl-accent-ink: #ffffff;
+    --gl-green: #1a7f37;
+    --gl-amber: #9a6700;
+  }
+}
+/* … and explicit override wins in both directions. */
+:root[data-theme="light"] {
+  --gl-bg: #ffffff; --gl-panel: #f6f8fa; --gl-panel-2: #eef1f5; --gl-border: #d8dee4;
+  --gl-fg: #1f2328; --gl-muted: #59636e; --gl-faint: #818b98;
+  --gl-accent: #7c3aed; --gl-accent-2: #6d28d9; --gl-accent-ink: #ffffff;
+  --gl-green: #1a7f37; --gl-amber: #9a6700;
+}
+:root[data-theme="dark"] {
+  --gl-bg: #0d1117; --gl-panel: #161b22; --gl-panel-2: #1c2230; --gl-border: #2a3038;
+  --gl-fg: #e6edf3; --gl-muted: #9aa7b4; --gl-faint: #6b7684;
+  --gl-accent: #a371f7; --gl-accent-2: #bd93ff; --gl-accent-ink: #f5efff;
+  --gl-green: #3fb950; --gl-amber: #d29922;
+}
+
+/* ---- base ---- */
+.gl-body, body.gl {
+  margin: 0;
+  background: var(--gl-bg);
+  color: var(--gl-fg);
+  font-family: var(--gl-sans);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+.gl a { color: var(--gl-accent-2); text-decoration: none; }
+.gl a:hover { text-decoration: underline; }
+.gl code, .gl kbd, .gl pre { font-family: var(--gl-mono); }
+.gl h1, .gl h2, .gl h3 { line-height: 1.2; letter-spacing: -0.02em; margin: 0; }
+
+.gl-wrap { max-width: var(--gl-maxw); margin: 0 auto; padding: 0 20px; }
+.gl-section { padding: 72px 0; border-top: 1px solid var(--gl-border); }
+.gl-eyebrow { color: var(--gl-accent-2); font-weight: 700; font-size: .8rem; letter-spacing: .08em; text-transform: uppercase; margin: 0 0 10px; }
+.gl-lede { color: var(--gl-muted); font-size: 1.05rem; max-width: 60ch; }
+.gl-hint { color: var(--gl-faint); font-size: .82rem; margin-top: 10px; }
+
+/* skip link */
+.gl-skip { position: absolute; left: -9999px; }
+.gl-skip:focus { left: 12px; top: 10px; z-index: 50; background: var(--gl-panel); color: var(--gl-fg); padding: 8px 12px; border-radius: 8px; }
+
+/* ---- nav ---- */
+.gl-nav { position: sticky; top: 0; z-index: 20; backdrop-filter: blur(10px);
+  background: var(--gl-bg);
+  background: color-mix(in srgb, var(--gl-bg) 82%, transparent); border-bottom: 1px solid var(--gl-border); }
+.gl-nav .gl-wrap { display: flex; align-items: center; gap: 18px; height: 60px; }
+.gl-brand { display: flex; align-items: center; gap: 10px; font-weight: 700; color: var(--gl-fg); font-size: 1.05rem; }
+.gl-brand svg { display: block; }
+.gl-nav nav { margin-left: auto; display: flex; align-items: center; gap: 22px; }
+.gl-nav nav a { color: var(--gl-muted); font-weight: 600; font-size: .95rem; }
+.gl-nav nav a:hover { color: var(--gl-fg); text-decoration: none; }
+.gl-nav-toggle { display: none; margin-left: auto; background: var(--gl-panel); color: var(--gl-fg);
+  border: 1px solid var(--gl-border); border-radius: 8px; padding: 8px 10px; cursor: pointer; }
+
+/* ---- buttons ---- */
+.gl-btn { display: inline-flex; align-items: center; gap: 8px; font-weight: 700; font-size: .95rem;
+  padding: 10px 16px; border-radius: 10px; border: 1px solid var(--gl-border); cursor: pointer; color: var(--gl-fg); background: transparent; }
+.gl-btn.primary { background: linear-gradient(180deg, var(--gl-accent), var(--gl-accent-2)); color: var(--gl-accent-ink); border-color: transparent; }
+.gl-btn.primary:hover { filter: brightness(1.07); text-decoration: none; }
+.gl-btn.ghost { background: var(--gl-panel); }
+.gl-btn.ghost:hover { border-color: var(--gl-accent); text-decoration: none; }
+
+/* ---- theme toggle ---- */
+.gl-theme-toggle { display: inline-grid; place-items: center; width: 38px; height: 38px; flex: none;
+  background: var(--gl-panel); color: var(--gl-fg); border: 1px solid var(--gl-border); border-radius: 10px; cursor: pointer; padding: 0; }
+.gl-theme-toggle:hover { border-color: var(--gl-accent); }
+.gl-theme-toggle:focus-visible { outline: 2px solid var(--gl-accent); outline-offset: 2px; }
+.gl-theme-toggle svg { width: 18px; height: 18px; display: block; }
+/* Icon reflects the active theme — CSS-only swap across system + forced themes. */
+.gl-theme-toggle .gl-sun { display: none; }
+.gl-theme-toggle .gl-moon { display: block; }
+@media (prefers-color-scheme: light) {
+  .gl-theme-toggle .gl-sun { display: block; }
+  .gl-theme-toggle .gl-moon { display: none; }
+}
+:root[data-theme="light"] .gl-theme-toggle .gl-sun { display: block; }
+:root[data-theme="light"] .gl-theme-toggle .gl-moon { display: none; }
+:root[data-theme="dark"] .gl-theme-toggle .gl-sun { display: none; }
+:root[data-theme="dark"] .gl-theme-toggle .gl-moon { display: block; }
+
+/* ---- hero ---- */
+.gl-hero { padding: 84px 0 64px; }
+.gl-hero h1 { font-size: clamp(2.1rem, 5.2vw, 3.4rem); font-weight: 800; }
+.gl-grad { background: linear-gradient(90deg, var(--gl-accent-2), #e9d5ff); -webkit-background-clip: text; background-clip: text; color: transparent; }
+.gl-hero p.sub { font-size: 1.2rem; color: var(--gl-muted); margin: 18px 0 28px; max-width: 56ch; }
+.gl-cta { display: flex; gap: 12px; flex-wrap: wrap; }
+.gl-hero-grid { display: grid; grid-template-columns: 1.05fr 1fr; gap: 44px; align-items: center; }
+@media (max-width: 860px) { .gl-hero-grid { grid-template-columns: 1fr; gap: 32px; } }
+
+/* ---- terminal ---- */
+.gl-term { background: var(--gl-panel); border: 1px solid var(--gl-border); border-radius: var(--gl-radius); overflow: hidden;
+  box-shadow: 0 20px 50px -30px rgba(0,0,0,.7); }
+.gl-term .bar { display: flex; align-items: center; gap: 7px; padding: 11px 14px; background: var(--gl-panel-2); border-bottom: 1px solid var(--gl-border); }
+.gl-term .dot { width: 11px; height: 11px; border-radius: 50%; }
+.gl-term .bar .t { margin-left: 10px; color: var(--gl-faint); font: 600 .8rem/1 var(--gl-mono); }
+.gl-term pre { margin: 0; padding: 16px; overflow-x: auto; font-size: .82rem; line-height: 1.65; color: var(--gl-fg); }
+.gl-term .pr { color: var(--gl-accent-2); }
+.gl-term .hd { color: var(--gl-faint); }
+.gl-term .n { color: var(--gl-accent-2); font-weight: 700; }
+.gl-term .loc { color: var(--gl-muted); }
+.gl-term .ok { color: var(--gl-green); }
+.gl-term .warn { color: var(--gl-amber); }
+
+/* ---- pills / tabs ---- */
+.gl-badges { display: flex; flex-wrap: wrap; gap: 8px; margin: 26px 0 0; padding: 0; list-style: none; }
+.gl-lang { font: 700 .72rem/1 var(--gl-mono); color: var(--gl-muted); background: var(--gl-panel);
+  border: 1px solid var(--gl-border); border-radius: 999px; padding: 7px 12px; }
+/* Interactive affordances apply only to real tabs (buttons carrying data-gl-tab).
+   A plain gl-lang is a static badge and must not look or focus like a control. */
+.gl-lang[data-gl-tab] { cursor: pointer; transition: color .12s, border-color .12s, background .12s; }
+.gl-lang[data-gl-tab]:hover { color: var(--gl-fg); border-color: var(--gl-accent); }
+.gl-lang[data-gl-tab]:focus-visible { outline: 2px solid var(--gl-accent); outline-offset: 2px; }
+.gl-lang[aria-selected="true"] { background: linear-gradient(180deg, var(--gl-accent), var(--gl-accent-2)); color: var(--gl-accent-ink); border-color: transparent; }
+
+/* ---- cards / grid ---- */
+.gl-grid { display: grid; gap: 18px; }
+.gl-grid.two { grid-template-columns: 1fr 1fr; }
+.gl-grid.feat { grid-template-columns: repeat(3, 1fr); }
+@media (max-width: 820px) { .gl-grid.feat { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 560px) { .gl-grid.two, .gl-grid.feat { grid-template-columns: 1fr; } }
+.gl-card { background: var(--gl-panel); border: 1px solid var(--gl-border); border-radius: var(--gl-radius); padding: 22px; }
+.gl-card h3 { font-size: 1.05rem; margin-bottom: 8px; display: flex; align-items: center; gap: 10px; }
+.gl-card p { color: var(--gl-muted); margin: 0; font-size: .95rem; }
+.gl-icon { width: 34px; height: 34px; flex: none; display: grid; place-items: center; border-radius: 9px;
+  background: color-mix(in srgb, var(--gl-accent) 18%, transparent); color: var(--gl-accent-2); }
+.gl-icon svg { width: 18px; height: 18px; }
+.gl-stat { font: 800 2rem/1 var(--gl-mono); color: var(--gl-accent-2); }
+
+/* ---- code blocks ---- */
+.gl-code { background: var(--gl-panel); border: 1px solid var(--gl-border); border-radius: var(--gl-radius);
+  padding: 16px 18px; overflow-x: auto; font-size: .85rem; line-height: 1.6; margin: 0; }
+.gl-code .c { color: var(--gl-faint); }
+.gl-code .k { color: var(--gl-accent-2); }
+.gl-code .s { color: var(--gl-green); }
+.gl-split { display: grid; grid-template-columns: 1fr 1fr; gap: 22px; align-items: start; }
+@media (max-width: 760px) { .gl-split { grid-template-columns: 1fr; } }
+
+/* ---- install snippets ---- */
+.gl-install { display: grid; gap: 14px; max-width: 760px; }
+.gl-snip { display: flex; align-items: center; gap: 12px; background: var(--gl-panel); border: 1px solid var(--gl-border); border-radius: 12px; padding: 6px 6px 6px 16px; }
+.gl-snip .lbl { font: 700 .72rem/1 var(--gl-mono); color: var(--gl-accent-2); text-transform: uppercase; letter-spacing: .05em; flex: none; width: 74px; }
+.gl-snip code { flex: 1; overflow-x: auto; white-space: nowrap; color: var(--gl-fg); font-size: .88rem; padding: 8px 0; }
+.gl-copy { flex: none; background: var(--gl-panel-2); color: var(--gl-muted); border: 1px solid var(--gl-border); border-radius: 8px; padding: 8px 12px; font: 700 .78rem/1 var(--gl-sans); cursor: pointer; }
+.gl-copy:hover { color: var(--gl-fg); border-color: var(--gl-accent); }
+.gl-copy.done { color: var(--gl-green); border-color: var(--gl-green); }
+
+/* ---- footer ---- */
+.gl-footer { border-top: 1px solid var(--gl-border); padding: 40px 0 60px; color: var(--gl-muted); }
+.gl-footer .gl-wrap { display: flex; flex-wrap: wrap; gap: 18px 28px; align-items: center; justify-content: space-between; }
+.gl-footer a { color: var(--gl-muted); font-weight: 600; font-size: .92rem; }
+.gl-footer a:hover { color: var(--gl-fg); }
+.gl-fnav { display: flex; flex-wrap: wrap; gap: 18px; }
+
+/* ---- mobile nav ---- */
+@media (max-width: 680px) {
+  .gl-nav nav { display: none; }
+  .gl-nav nav.open { display: flex; position: absolute; top: 60px; left: 0; right: 0; flex-direction: column; gap: 0;
+    background: var(--gl-bg); border-bottom: 1px solid var(--gl-border); padding: 8px 20px 16px; }
+  .gl-nav nav.open a { padding: 10px 0; }
+  .gl-nav nav.open .gl-btn { display: none; }
+  .gl-nav-toggle { display: block; }
+}

--- a/docs/gloam.js
+++ b/docs/gloam.js
@@ -1,0 +1,145 @@
+/*!
+ * gloam.js — optional, dependency-free behaviors for the gloam design language.
+ * https://github.com/richardwooding/gloam · MIT
+ *
+ * Everything is data-attribute driven and no-ops when the elements are absent,
+ * so you can include it unconditionally. Runs on DOMContentLoaded.
+ *
+ *   Copy button:  <button class="gl-copy" data-gl-copy="snippetId">Copy</button>
+ *                 <code id="snippetId">…</code>
+ *   Tabs:         <button class="gl-lang" data-gl-tab="one" ...>One</button>
+ *                 container: <div data-gl-tabs>…buttons…</div>
+ *                 panels:    <div data-gl-panel="one">…</div>  (hidden unless selected)
+ *   Mobile nav:   <button data-gl-nav-toggle="navId">☰</button>  <nav id="navId">…</nav>
+ *   Theme toggle: <button data-gl-theme-toggle aria-label="Toggle color theme">…</button>
+ *                 flips light/dark on <html data-theme>, persisted in localStorage.
+ *   Year:         <span data-gl-year></span>
+ */
+(function () {
+  "use strict";
+  function ready(fn) {
+    if (document.readyState !== "loading") fn();
+    else document.addEventListener("DOMContentLoaded", fn);
+  }
+
+  // Effective theme: an explicit data-theme wins, else the system preference.
+  // (Reading the computed --gl-bg is unreliable — browsers serialize it as rgb().)
+  function isDark() {
+    var explicit = document.documentElement.getAttribute("data-theme");
+    if (explicit) return explicit === "dark";
+    return !window.matchMedia("(prefers-color-scheme: light)").matches;
+  }
+
+  // Restore a persisted theme as early as this script runs. For flash-free
+  // restore, also add this one-liner in <head> (runs before first paint):
+  //   <script>try{var t=localStorage.getItem("gl-theme");if(t)document.documentElement.setAttribute("data-theme",t)}catch(e){}</script>
+  try {
+    var savedTheme = localStorage.getItem("gl-theme");
+    if (savedTheme === "light" || savedTheme === "dark") {
+      document.documentElement.setAttribute("data-theme", savedTheme);
+    }
+  } catch (e) { /* ignore */ }
+
+  ready(function () {
+    // Current year.
+    document.querySelectorAll("[data-gl-year]").forEach(function (el) {
+      el.textContent = new Date().getFullYear();
+    });
+
+    // Theme toggle: flip light/dark, persist the choice, reflect it in aria-pressed.
+    var themeToggles = document.querySelectorAll("[data-gl-theme-toggle]");
+    function syncToggles() {
+      var dark = isDark();
+      themeToggles.forEach(function (b) { b.setAttribute("aria-pressed", String(dark)); });
+    }
+    syncToggles();
+    themeToggles.forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var next = isDark() ? "light" : "dark";
+        document.documentElement.setAttribute("data-theme", next);
+        try { localStorage.setItem("gl-theme", next); } catch (e) { /* ignore */ }
+        syncToggles();
+      });
+    });
+
+    // Copy-to-clipboard buttons.
+    document.querySelectorAll("[data-gl-copy]").forEach(function (btn) {
+      // Capture the label once and clear any pending reset, so rapid repeat
+      // clicks can't latch "Copied" as the restore text.
+      var originalHTML = btn.innerHTML;
+      var resetTimer = null;
+      btn.addEventListener("click", function () {
+        var target = document.getElementById(btn.getAttribute("data-gl-copy"));
+        if (!target) return;
+        var text = target.textContent;
+        function done() {
+          btn.textContent = "Copied";
+          btn.classList.add("done");
+          if (resetTimer) clearTimeout(resetTimer);
+          // Restore via innerHTML so any nested markup (icons) survives.
+          resetTimer = setTimeout(function () { btn.innerHTML = originalHTML; btn.classList.remove("done"); }, 1400);
+        }
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text).then(done).catch(fallback);
+        } else {
+          fallback();
+        }
+        function fallback() {
+          var ta = document.createElement("textarea");
+          ta.value = text; ta.style.position = "absolute"; ta.style.left = "-9999px";
+          document.body.appendChild(ta); ta.select();
+          // Only signal success if the copy actually happened.
+          try { if (document.execCommand("copy")) done(); } catch (e) { /* ignore */ }
+          document.body.removeChild(ta);
+        }
+      });
+    });
+
+    // Pill tabs: clicking [data-gl-tab=X] inside [data-gl-tabs] shows [data-gl-panel=X].
+    document.querySelectorAll("[data-gl-tabs]").forEach(function (group) {
+      var tabs = group.querySelectorAll("[data-gl-tab]");
+      // Scope panels to the nearest ancestor that actually contains them, so
+      // multiple tab groups on a page don't toggle each other's panels — while
+      // still working when the group and its panels sit in sibling columns
+      // (e.g. hero pills in one column, terminal panels in the other).
+      var container = group.parentElement;
+      while (container && !container.querySelector("[data-gl-panel]")) {
+        container = container.parentElement;
+      }
+      if (!container) container = document;
+      // Only toggle panels this group owns, so two tab groups sharing an
+      // ancestor don't hide each other's panels.
+      var owned = Object.create(null);
+      tabs.forEach(function (t) { owned[t.getAttribute("data-gl-tab")] = true; });
+      function select(name) {
+        tabs.forEach(function (t) { t.setAttribute("aria-selected", String(t.getAttribute("data-gl-tab") === name)); });
+        container.querySelectorAll("[data-gl-panel]").forEach(function (p) {
+          var panelName = p.getAttribute("data-gl-panel");
+          if (owned[panelName]) p.hidden = panelName !== name;
+        });
+      }
+      tabs.forEach(function (t) {
+        t.addEventListener("click", function () { select(t.getAttribute("data-gl-tab")); });
+      });
+      var initial = group.querySelector('[data-gl-tab][aria-selected="true"]') || tabs[0];
+      if (initial) select(initial.getAttribute("data-gl-tab"));
+    });
+
+    // Mobile nav toggle; closes when a link inside is tapped.
+    document.querySelectorAll("[data-gl-nav-toggle]").forEach(function (btn) {
+      var nav = document.getElementById(btn.getAttribute("data-gl-nav-toggle"));
+      if (!nav) return;
+      btn.addEventListener("click", function () {
+        var open = nav.classList.toggle("open");
+        btn.setAttribute("aria-expanded", String(open));
+      });
+      nav.addEventListener("click", function (e) {
+        // closest("a") so clicks on elements nested inside a link still close.
+        if (e.target.closest && e.target.closest("a")) {
+          nav.classList.remove("open");
+          btn.setAttribute("aria-expanded", "false");
+        }
+      });
+    });
+  });
+})();

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,209 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>txtr — extract strings from binaries, better than strings(1)</title>
+<meta name="description" content="A GNU strings-compatible extractor written in Go: binary-format aware, with security triage (entropy + secret detection), archive recursion, JSON/stats output, and parallel scanning.">
+<meta property="og:title" content="txtr">
+<meta property="og:description" content="Extract strings from binaries — better than GNU strings. Triage, archive recursion, JSON, single Go binary.">
+<meta property="og:type" content="website">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><rect width='24' height='24' rx='6' fill='%23161b22'/><rect x='5' y='12' width='3.5' height='7' rx='1' fill='%23a371f7'/><rect x='10.25' y='8' width='3.5' height='11' rx='1' fill='%23bd93ff'/><rect x='15.5' y='4' width='3.5' height='15' rx='1' fill='%23d2b3ff'/></svg>">
+<script>try{var t=localStorage.getItem("gl-theme");if(t)document.documentElement.setAttribute("data-theme",t)}catch(e){}</script>
+<link rel="stylesheet" href="gloam.css">
+</head>
+<body class="gl">
+<a class="gl-skip" href="#main">Skip to content</a>
+
+<header class="gl-nav">
+  <div class="gl-wrap">
+    <span class="gl-brand">
+      <svg width="26" height="26" viewBox="0 0 24 24" aria-hidden="true">
+        <rect width="24" height="24" rx="6" fill="var(--gl-panel-2)"/>
+        <rect x="5" y="12" width="3.5" height="7" rx="1" fill="var(--gl-accent)"/>
+        <rect x="10.25" y="8" width="3.5" height="11" rx="1" fill="var(--gl-accent-2)"/>
+        <rect x="15.5" y="4" width="3.5" height="15" rx="1" fill="#d2b3ff"/>
+      </svg>
+      txtr
+    </span>
+    <button class="gl-nav-toggle" aria-label="Toggle navigation" data-gl-nav-toggle="nav" aria-expanded="false">☰</button>
+    <nav id="nav">
+      <a href="#features">Features</a>
+      <a href="#triage">Triage</a>
+      <a href="#formats">Formats</a>
+      <a href="#install">Install</a>
+      <button class="gl-theme-toggle" data-gl-theme-toggle aria-label="Toggle color theme" aria-pressed="true">
+        <svg class="gl-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
+        <svg class="gl-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M19.1 4.9l-1.4 1.4M6.3 17.7l-1.4 1.4"/></svg>
+      </button>
+      <a class="gl-btn ghost" href="https://github.com/richardwooding/txtr">GitHub ★</a>
+    </nav>
+  </div>
+</header>
+
+<main id="main">
+  <section class="gl-hero">
+    <div class="gl-wrap gl-hero-grid">
+      <div>
+        <p class="gl-eyebrow">go · single binary · strings(1) compatible</p>
+        <h1>Pull strings out of binaries. <span class="gl-grad">Better than strings(1).</span></h1>
+        <p class="sub">A drop-in <code>strings</code> replacement written in Go — but format-aware, secret-scanning, archive-diving, and JSON-speaking. From quick extraction to first-pass firmware triage in one command.</p>
+        <div class="gl-cta">
+          <a class="gl-btn primary" href="#install">Install</a>
+          <a class="gl-btn ghost" href="https://github.com/richardwooding/txtr">View on GitHub</a>
+        </div>
+        <p class="gl-hint">MIT licensed · macOS · Linux · Windows · FreeBSD · container images</p>
+      </div>
+      <div class="gl-term">
+        <div class="bar">
+          <span class="dot" style="background:#ff5f56"></span>
+          <span class="dot" style="background:#ffbd2e"></span>
+          <span class="dot" style="background:#27c93f"></span>
+          <span class="t">txtr</span>
+        </div>
+<pre><span class="pr">$</span> txtr --secrets firmware.bin
+<span class="warn">[SECRET]</span>    <span class="loc">0x001a40</span>  AWS Access Key   AKIAIOSFODNN7EXAMPLE
+<span class="warn">[SECRET]</span>    <span class="loc">0x002f10</span>  PEM Private Key  -----BEGIN RSA PRIVATE KEY-----
+<span class="n">[HIGH-ENT]</span>  <span class="loc">0x004012</span>  entropy=7.8      gB7x9K2pQ4rT6yU8wA1z…
+<span class="ok">[URL]</span>       <span class="loc">0x005120</span>  https://c2.example.com/beacon
+<span class="ok">[IPv4]</span>      <span class="loc">0x006004</span>  10.0.0.5</pre>
+      </div>
+    </div>
+  </section>
+
+  <section class="gl-section" id="features">
+    <div class="gl-wrap">
+      <p class="gl-eyebrow">what you get</p>
+      <h2>Everything strings does — and the parts it never did.</h2>
+      <p class="gl-lede" style="margin-top:14px">Compatible where it counts, then far past it: txtr understands the binary it's reading, scores what it finds, and speaks JSON.</p>
+      <div class="gl-grid feat" style="margin-top:32px">
+
+        <div class="gl-card">
+          <h3><span class="gl-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg></span>strings(1) compatible</h3>
+          <p>The flags you already know — <code>-n</code>, <code>-t</code>, <code>-e</code>, <code>-f</code>, <code>-o</code>, <code>-s</code> — behave the same, including UTF-16/32 BE/LE encodings. Drop it in and go.</p>
+        </div>
+
+        <div class="gl-card">
+          <h3><span class="gl-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 9h18"/></svg></span>Binary-format aware</h3>
+          <p>Detects ELF, PE, and Mach-O and scans the sections that actually hold text (<code>.data</code>, <code>.rdata</code>) instead of the raw file — less noise, more signal.</p>
+        </div>
+
+        <div class="gl-card">
+          <h3><span class="gl-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2l7 4v6c0 5-3 8-7 10-4-2-7-5-7-10V6z"/></svg></span>Security triage</h3>
+          <p>Score every string by Shannon entropy, classify it (URL, email, IP, domain, path, hex, base64, UUID), and flag secrets — AWS keys, PEM, JWTs, GitHub/Slack/Stripe tokens.</p>
+        </div>
+
+        <div class="gl-card">
+          <h3><span class="gl-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 7h5l2 3h11v9H3z"/><path d="M3 7V4h6"/></svg></span>Archive recursion</h3>
+          <p><code>-r</code> descends into zip, apk, jar, tar, gz, bz2, xz, zstd and deb — labelling each hit with a virtual <code>!/</code> path, with decompression-bomb guards built in.</p>
+        </div>
+
+        <div class="gl-card">
+          <h3><span class="gl-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 3H5a2 2 0 0 0-2 2v3M16 3h3a2 2 0 0 1 2 2v3M8 21H5a2 2 0 0 1-2-2v-3M16 21h3a2 2 0 0 0 2-2v-3"/></svg></span>JSON &amp; stats</h3>
+          <p><code>--json</code> emits jq-friendly, CI-ready output; <code>--stats</code> rolls up encoding and length distributions, longest strings, and a triage summary for fast file triage.</p>
+        </div>
+
+        <div class="gl-card">
+          <h3><span class="gl-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M13 2L3 14h7l-1 8 10-12h-7z"/></svg></span>Fast &amp; parallel</h3>
+          <p>Processes many files across all CPU cores by default (tune with <code>-P</code>), shipped as one static Go binary with no runtime dependencies.</p>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <section class="gl-section" id="triage">
+    <div class="gl-wrap">
+      <p class="gl-eyebrow">beyond extraction</p>
+      <h2>A first-pass triage tool for firmware &amp; malware.</h2>
+      <p class="gl-lede" style="margin-top:14px">Recurse into a package, surface secrets and high-entropy blobs, and gate CI on the JSON — or get a one-screen composition summary.</p>
+      <div class="gl-split" style="margin-top:28px">
+<pre class="gl-code"><span class="c"># Triage a Debian package: ar → data.tar.xz → ELF</span>
+<span class="k">txtr</span> -r --triage pkg.deb
+
+<span class="c"># Fail CI when a shipped binary leaks secrets</span>
+<span class="k">txtr</span> --triage -j app.bin \
+  | jq <span class="s">'.files[0].strings[]
+       | select((.secrets|length)>0)'</span>
+
+<span class="c"># Only URLs and emails, case-insensitive</span>
+<span class="k">txtr</span> -i -m <span class="s">'https?://\S+'</span> -m <span class="s">'\S+@\S+'</span> fw.bin</pre>
+<pre class="gl-code"><span class="c"># txtr --stats binary.exe</span>
+Binary format:   PE (Windows executable)
+Sections:        .data, .rdata
+Total strings:   <span class="k">1,234</span>
+Encoding:        <span class="k">89%</span> ASCII · 10% UTF-8 · 1% high-byte
+Length:          4–10: 65% · 11–50: 28% · 50+: 7%
+Longest:         256 <span class="c">@ 0x4000</span> "Copyright (c) 2025…"</pre>
+      </div>
+    </div>
+  </section>
+
+  <section class="gl-section" id="formats">
+    <div class="gl-wrap">
+      <p class="gl-eyebrow">coverage</p>
+      <h2>Formats it reads.</h2>
+      <p class="gl-lede" style="margin-top:14px">Executable formats are section-scanned; archive and compression containers are recursed with <code>-r</code>.</p>
+      <ul class="gl-badges" aria-label="Supported binary formats">
+        <li class="gl-lang">ELF</li>
+        <li class="gl-lang">PE</li>
+        <li class="gl-lang">Mach-O</li>
+      </ul>
+      <ul class="gl-badges" aria-label="Supported archive and compression containers">
+        <li class="gl-lang">zip</li>
+        <li class="gl-lang">apk</li>
+        <li class="gl-lang">jar</li>
+        <li class="gl-lang">ipa</li>
+        <li class="gl-lang">aar</li>
+        <li class="gl-lang">tar</li>
+        <li class="gl-lang">gzip</li>
+        <li class="gl-lang">bzip2</li>
+        <li class="gl-lang">xz</li>
+        <li class="gl-lang">zstd</li>
+        <li class="gl-lang">deb / ar</li>
+      </ul>
+      <p class="gl-hint">Encodings: 7-/8-bit ASCII · UTF-16 BE/LE · UTF-32 BE/LE · UTF-8 (locale, escape, hex, highlight)</p>
+    </div>
+  </section>
+
+  <section class="gl-section" id="install">
+    <div class="gl-wrap">
+      <p class="gl-eyebrow">install</p>
+      <h2>Grab a binary, a container, or go install.</h2>
+      <p class="gl-lede" style="margin-top:14px">Prebuilt for macOS (Intel/ARM), Linux (amd64/arm64/armv6/armv7), Windows, and FreeBSD.</p>
+      <div class="gl-install" style="margin-top:26px">
+        <div class="gl-snip">
+          <span class="lbl">brew</span>
+          <code id="i1">brew install richardwooding/tap/txtr</code>
+          <button class="gl-copy" data-gl-copy="i1">Copy</button>
+        </div>
+        <div class="gl-snip">
+          <span class="lbl">go</span>
+          <code id="i2">go install github.com/richardwooding/txtr/cmd/txtr@latest</code>
+          <button class="gl-copy" data-gl-copy="i2">Copy</button>
+        </div>
+        <div class="gl-snip">
+          <span class="lbl">docker</span>
+          <code id="i3">docker pull ghcr.io/richardwooding/txtr:latest</code>
+          <button class="gl-copy" data-gl-copy="i3">Copy</button>
+        </div>
+      </div>
+      <p class="gl-hint">Prefer a raw download? See the <a href="https://github.com/richardwooding/txtr/releases">GitHub releases</a> for signed archives and checksums.</p>
+    </div>
+  </section>
+</main>
+
+<footer class="gl-footer">
+  <div class="gl-wrap">
+    <span class="gl-brand" style="font-size:.98rem">txtr · MIT · <span data-gl-year></span></span>
+    <nav class="gl-fnav">
+      <a href="https://github.com/richardwooding/txtr">GitHub</a>
+      <a href="https://github.com/richardwooding/txtr/releases">Releases</a>
+      <a href="https://github.com/richardwooding/txtr/blob/main/LICENSE">License</a>
+    </nav>
+  </div>
+</footer>
+
+<script src="gloam.js" defer></script>
+</body>
+</html>

--- a/docs/sync-gloam.sh
+++ b/docs/sync-gloam.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+# sync-gloam.sh — vendor gloam.css and gloam.js from the canonical repo.
+#
+# gloam lives at github.com/richardwooding/gloam; consumers keep a *copy* of
+# gloam.css/gloam.js next to their page. Run this to refresh that copy so the
+# consumer doesn't drift from the design system.
+#
+# Usage:
+#   sync-gloam.sh [target-dir] [ref]
+#     target-dir  where gloam.css/gloam.js live (default: the script's own dir)
+#     ref         branch or commit to sync from (default: main)
+#
+# Both files are fetched from the same resolved commit, and the commit is
+# recorded in <target-dir>/.gloam-version for drift detection.
+set -eu
+
+REPO="richardwooding/gloam"
+DEFAULT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+TARGET="${1:-$DEFAULT_DIR}"
+REF="${2:-main}"
+BASE="https://raw.githubusercontent.com/${REPO}"
+
+[ -d "$TARGET" ] || { echo "sync-gloam: target dir not found: $TARGET" >&2; exit 1; }
+
+# Never leave half-downloaded .tmp files behind if the script is interrupted
+# or a download fails midway.
+trap 'rm -f "$TARGET"/gloam.css.tmp "$TARGET"/gloam.js.tmp' EXIT INT TERM
+
+# Resolve the ref to a commit SHA so both files come from one commit (no race
+# if the branch moves mid-sync). Query the exact ref paths so we don't match
+# other refs merely ending in $REF, and take the last line so an annotated tag
+# resolves to its dereferenced commit (refs/tags/x^{}) rather than the tag
+# object. A raw SHA (which matches no ref path) falls back to itself.
+SHA="$(git ls-remote "https://github.com/${REPO}.git" "refs/heads/${REF}" "refs/tags/${REF}" 2>/dev/null | tail -1 | cut -f1)"
+[ -n "$SHA" ] || SHA="$REF"
+
+# Download to temp files and swap them in only once both succeed, so an
+# interrupted or failed sync never leaves a half-updated pair.
+for f in gloam.css gloam.js; do
+  echo "↓ ${f} @ ${SHA}"
+  curl -fsSL "${BASE}/${SHA}/${f}" -o "${TARGET}/${f}.tmp"
+done
+for f in gloam.css gloam.js; do
+  mv "${TARGET}/${f}.tmp" "${TARGET}/${f}"
+done
+
+printf 'repo=%s\nref=%s\ncommit=%s\n' "$REPO" "$REF" "$SHA" > "${TARGET}/.gloam-version"
+echo "✓ gloam synced to ${TARGET} (${SHA})"


### PR DESCRIPTION
## What

A dark-first, terminal-styled **gloam** landing page for txtr, served from `docs/`, set up consistently with your other repos (codemetrics, projectdetect, capetown-opendata-mcp, feed-mcp).

## Contents

- **`docs/index.html`** — linked-mode gloam page (vendored `gloam.css`/`gloam.js`, no external requests). Sections: hero with a `--secrets` triage terminal, feature grid (strings(1) compatibility, binary-format awareness, security triage, archive recursion, JSON/stats, parallel), a triage/stats showcase, supported formats & containers, and copy-button install snippets (brew / go / docker).
- **`docs/sync-gloam.sh`** + **`docs/.gloam-version`** — vendored from [richardwooding/gloam](https://github.com/richardwooding/gloam)@`4f8b9ff` (includes the nav aria-expanded + static-badge a11y fix).
- **`.github/workflows/pages.yml`** — Node24 actions (checkout@v7, configure-pages@v6 w/ `enablement: true`, upload-pages-artifact@v5, deploy-pages@v5).
- **`.github/workflows/gloam-sync.yml`** — weekly PR when the vendored gloam copy drifts (`GLOAM_DIR: docs`).
- README **Website** link.

Publishes to https://richardwooding.github.io/txtr/ once merged (`enablement: true` auto-enables Pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)