### PR TITLE
docs: use plain 'GNU strings' instead of strings(1)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>txtr — extract strings from binaries, better than strings(1)</title>
+<title>txtr — extract strings from binaries, better than GNU strings</title>
 <meta name="description" content="A GNU strings-compatible extractor: binary-format aware, with security triage (entropy + secret detection), archive recursion, JSON/stats output, and parallel scanning.">
 <meta property="og:title" content="txtr">
 <meta property="og:description" content="Extract strings from binaries — better than GNU strings. Triage, archive recursion, JSON, single static binary.">
@@ -45,8 +45,8 @@
   <section class="gl-hero">
     <div class="gl-wrap gl-hero-grid">
       <div>
-        <p class="gl-eyebrow">single binary · cross-platform · strings(1) compatible</p>
-        <h1>Pull strings out of binaries. <span class="gl-grad">Better than strings(1).</span></h1>
+        <p class="gl-eyebrow">single binary · cross-platform · GNU strings compatible</p>
+        <h1>Pull strings out of binaries. <span class="gl-grad">Better than GNU strings.</span></h1>
         <p class="sub">A drop-in <code>strings</code> replacement — but format-aware, secret-scanning, archive-diving, and JSON-speaking. From quick extraction to first-pass firmware triage in one command.</p>
         <div class="gl-cta">
           <a class="gl-btn primary" href="#install">Install</a>
@@ -79,7 +79,7 @@
       <div class="gl-grid feat" style="margin-top:32px">
 
         <div class="gl-card">
-          <h3><span class="gl-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg></span>strings(1) compatible</h3>
+          <h3><span class="gl-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg></span>GNU strings compatible</h3>
           <p>The flags you already know — <code>-n</code>, <code>-t</code>, <code>-e</code>, <code>-f</code>, <code>-o</code>, <code>-s</code> — behave the same, including UTF-16/32 BE/LE encodings. Drop it in and go.</p>
         </div>
 


### PR DESCRIPTION
Replaces the `strings(1)` man-page notation with plain "GNU strings" across the title, hero, and feature card — clearer for a general audience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)