### PR TITLE
docs: link footer back to the hub

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -197,6 +197,7 @@ Longest:         256 <span class="c">@ 0x4000</span> "Copyright (c) 2025…"</pr
   <div class="gl-wrap">
     <span class="gl-brand" style="font-size:.98rem">txtr · MIT · <span data-gl-year></span></span>
     <nav class="gl-fnav">
+      <a href="https://richardwooding.github.io/">Richard Wooding</a>
       <a href="https://github.com/richardwooding/txtr">GitHub</a>
       <a href="https://github.com/richardwooding/txtr/releases">Releases</a>
       <a href="https://github.com/richardwooding/txtr/blob/main/LICENSE">License</a>


### PR DESCRIPTION
Adds a "Richard Wooding" backlink to the site's hub as the first link in the footer navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)